### PR TITLE
Updated the SettingsDataStoreImpl

### DIFF
--- a/app/src/main/java/com/anthonyla/paperize/data/settings/SettingsDataStoreImpl.kt
+++ b/app/src/main/java/com/anthonyla/paperize/data/settings/SettingsDataStoreImpl.kt
@@ -11,8 +11,9 @@ import com.anthonyla.paperize.core.SettingsConstants.SETTINGS_DATASTORE
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
-private val Context.dataStore : DataStore<Preferences> by preferencesDataStore(name = SETTINGS_DATASTORE)
-class SettingsDataStoreImpl @Inject constructor (private val context: Context): SettingsDataStore {
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = SETTINGS_DATASTORE)
+
+class SettingsDataStoreImpl(private val context: Context) : SettingsDataStore {
     override suspend fun putBoolean(key: String, value: Boolean) {
         val preferencesKey = booleanPreferencesKey(key)
         context.dataStore.edit {


### PR DESCRIPTION
There was no need of Injecting the context as we have manually provided it in our AppModule while providing the object of SettingsDataStore.