### PR TITLE
add skip in non-interactive state setting

### DIFF
--- a/app/src/main/java/com/anthonyla/paperize/core/SettingsConstants.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/SettingsConstants.kt
@@ -48,4 +48,5 @@ object SettingsConstants {
     const val START_MINUTE = "start_minute"
     const val SHUFFLE = "shuffle"
     const val SKIP_LANDSCAPE = "skip_landscape"
+    const val SKIP_NON_INTERACTIVE = "skip_non_interactive"
 }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/PaperizeApp.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/PaperizeApp.kt
@@ -525,6 +525,10 @@ fun PaperizeApp(
                 },
                 onSkipLandscapeChange = { skipLandscape ->
                     settingsViewModel.onEvent(SettingsEvent.SetSkipLandscape(skipLandscape))
+                },
+                onSkipNonInteractiveChange = {
+                    skipNonInteractive ->
+                    settingsViewModel.onEvent(SettingsEvent.SetSkipNonInteractive(skipNonInteractive))
                 }
             )
         }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/home_screen/HomeScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/home_screen/HomeScreen.kt
@@ -65,7 +65,8 @@ fun HomeScreen(
     onStartTimeChange: (TimePickerState) -> Unit,
     onShuffleCheck: (Boolean) -> Unit,
     onRefreshChange: (Boolean) -> Unit,
-    onSkipLandscapeChange: (Boolean) -> Unit
+    onSkipLandscapeChange: (Boolean) -> Unit,
+    onSkipNonInteractiveChange: (Boolean) -> Unit,
 ) {
     val tabItems = getTabItems()
     val pagerState = rememberPagerState(0) { tabItems.size }
@@ -144,7 +145,8 @@ fun HomeScreen(
                         onStartTimeChange = onStartTimeChange,
                         onShuffleCheck = onShuffleCheck,
                         onRefreshChange = onRefreshChange,
-                        onSkipLandscapeChange = onSkipLandscapeChange
+                        onSkipLandscapeChange = onSkipLandscapeChange,
+                        onSkipNonInteractiveChange = onSkipNonInteractiveChange
                     )
                     else -> LibraryScreen(
                         albums = albums,

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/settings_screen/SettingsEvent.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/settings_screen/SettingsEvent.kt
@@ -35,4 +35,5 @@ sealed class SettingsEvent {
     data class SetShuffle(val shuffle: Boolean): SettingsEvent()
     data class SetRefresh(val refresh: Boolean): SettingsEvent()
     data class SetSkipLandscape(val skipLandscape: Boolean): SettingsEvent()
+    data class SetSkipNonInteractive(val skipNonInteractive: Boolean): SettingsEvent()
 }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/settings_screen/SettingsState.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/settings_screen/SettingsState.kt
@@ -41,7 +41,8 @@ data class SettingsState(
         val changeStartTime: Boolean = false,
         val startTime: Pair<Int, Int> = Pair(0, 0),
         val refresh: Boolean = true,
-        val skipLandscape: Boolean = false
+        val skipLandscape: Boolean = false,
+        val skipNonInteractive: Boolean = false
     )
 
     data class EffectSettings(
@@ -79,6 +80,7 @@ data class SettingsState(
         val lockAlbumName: String,
         val homeAlbumName: String,
         val shuffle: Boolean,
-        val skipLandscape: Boolean
+        val skipLandscape: Boolean,
+        val skipNonInteractive: Boolean
     )
 }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/settings_screen/SettingsViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/settings_screen/SettingsViewModel.kt
@@ -109,7 +109,8 @@ class SettingsViewModel @Inject constructor(
         settingsDataStoreImpl.getIntFlow(SettingsConstants.START_MINUTE),
         settingsDataStoreImpl.getBooleanFlow(SettingsConstants.SHUFFLE),
         settingsDataStoreImpl.getBooleanFlow(SettingsConstants.REFRESH),
-        settingsDataStoreImpl.getBooleanFlow(SettingsConstants.SKIP_LANDSCAPE)
+        settingsDataStoreImpl.getBooleanFlow(SettingsConstants.SKIP_LANDSCAPE),
+        settingsDataStoreImpl.getBooleanFlow(SettingsConstants.SKIP_NON_INTERACTIVE)
     ) { flows ->
         ScheduleSettings(
             scheduleSeparately = flows[0] as Boolean? ?: false,
@@ -121,7 +122,8 @@ class SettingsViewModel @Inject constructor(
             startTime = Pair(flows[6] as Int? ?: 0, flows[7] as Int? ?: 0),
             shuffle = flows[8] as Boolean? ?: true,
             refresh = flows[9] as Boolean? ?: true,
-            skipLandscape = flows[10] as Boolean? ?: false
+            skipLandscape = flows[10] as Boolean? ?: false,
+            skipNonInteractive = flows[11] as Boolean? ?: false,
         )
     }
 
@@ -555,6 +557,13 @@ class SettingsViewModel @Inject constructor(
                 }
             }
 
+
+            is SettingsEvent.SetSkipNonInteractive -> {
+                viewModelScope.launch {
+                    settingsDataStoreImpl.putBoolean(SettingsConstants.SKIP_NON_INTERACTIVE, event.skipNonInteractive)
+                }
+            }
+
             is SettingsEvent.Reset -> {
                 viewModelScope.launch {
                     val keysToDelete = listOf(
@@ -598,7 +607,8 @@ class SettingsViewModel @Inject constructor(
                         SettingsConstants.START_MINUTE,
                         SettingsConstants.SHUFFLE,
                         SettingsConstants.REFRESH,
-                        SettingsConstants.SKIP_LANDSCAPE
+                        SettingsConstants.SKIP_LANDSCAPE,
+                        SettingsConstants.SKIP_NON_INTERACTIVE
                     )
                     settingsDataStoreImpl.clear(keysToDelete)
                 }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/wallpaper_screen/WallpaperScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/wallpaper_screen/WallpaperScreen.kt
@@ -47,6 +47,7 @@ import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.co
 import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.RefreshSwitch
 import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.ShuffleSwitch
 import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.SkipLandscapeSwitch
+import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.SkipNonInteractiveSwitch
 import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.TimeSliders
 import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.VignetteSwitchAndSlider
 import com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components.WallpaperPreviewAndScale
@@ -83,7 +84,8 @@ fun WallpaperScreen(
     onStartTimeChange: (TimePickerState) -> Unit,
     onShuffleCheck: (Boolean) -> Unit,
     onRefreshChange: (Boolean) -> Unit,
-    onSkipLandscapeChange: (Boolean) -> Unit
+    onSkipLandscapeChange: (Boolean) -> Unit,
+    onSkipNonInteractiveChange: (Boolean) -> Unit
 ) {
     val shouldShowScreen = wallpaperSettings.setHomeWallpaper || wallpaperSettings.setLockWallpaper
     val shouldShowSettings = shouldShowScreen && homeSelectedAlbum != null && lockSelectedAlbum != null
@@ -279,6 +281,10 @@ fun WallpaperScreen(
                     SkipLandscapeSwitch(
                         skipLandscape = scheduleSettings.skipLandscape,
                         onSkipLandscapeChange = onSkipLandscapeChange
+                    )
+                    SkipNonInteractiveSwitch(
+                        skipNonInteractive = scheduleSettings.skipNonInteractive,
+                        onSkipNonInteractiveChange = onSkipNonInteractiveChange
                     )
                 }
             }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/wallpaper_screen/components/SkipNonInteractiveSwitch.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/presentation/wallpaper_screen/components/SkipNonInteractiveSwitch.kt
@@ -1,0 +1,61 @@
+package com.anthonyla.paperize.feature.wallpaper.presentation.wallpaper_screen.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.anthonyla.paperize.R
+
+@Composable
+fun SkipNonInteractiveSwitch(
+    skipNonInteractive: Boolean,
+    onSkipNonInteractiveChange: (Boolean) -> Unit
+) {
+    Surface(
+        tonalElevation = 10.dp,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.skip_non_interactive_state),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.W500
+                )
+                Text(
+                    text = stringResource(R.string.prevent_changing_during_non_interactive_state),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = skipNonInteractive,
+                onCheckedChange = onSkipNonInteractiveChange
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/wallpaper_service/HomeWallpaperService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/wallpaper_service/HomeWallpaperService.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.Log
 import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
@@ -148,7 +149,8 @@ class HomeWallpaperService: Service() {
             lockAlbumName = settingsDataStoreImpl.getString(SettingsConstants.LOCK_ALBUM_NAME) ?: "",
             homeAlbumName = settingsDataStoreImpl.getString(SettingsConstants.HOME_ALBUM_NAME) ?: "",
             shuffle = settingsDataStoreImpl.getBoolean(SettingsConstants.SHUFFLE) ?: true,
-            skipLandscape = settingsDataStoreImpl.getBoolean(SettingsConstants.SKIP_LANDSCAPE) ?: false
+            skipLandscape = settingsDataStoreImpl.getBoolean(SettingsConstants.SKIP_LANDSCAPE) ?: false,
+            skipNonInteractive = settingsDataStoreImpl.getBoolean(SettingsConstants.SKIP_NON_INTERACTIVE) ?: false
         )
     }
 
@@ -169,6 +171,16 @@ class HomeWallpaperService: Service() {
                 Log.d("PaperizeWallpaperChanger", "Skipping wallpaper change - device is in landscape mode")
                 onDestroy()
                 return
+            }
+
+            if (settings.skipNonInteractive){
+                val powerManager = context.getSystemService(POWER_SERVICE) as PowerManager
+                if (!powerManager.isInteractive){
+                    Log.d(
+                        "PaperizeWallpaperChanger", "Skipping wallpaper change - device is in non-interactive state")
+                    onDestroy()
+                    return
+                }
             }
 
             var homeAlbum = selectedAlbum.find { it.album.initialAlbumName == settings.homeAlbumName }

--- a/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/wallpaper_service/LockWallpaperService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/feature/wallpaper/wallpaper_service/LockWallpaperService.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.Log
 import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
@@ -136,7 +137,8 @@ class LockWallpaperService: Service() {
             lockAlbumName = settingsDataStoreImpl.getString(SettingsConstants.LOCK_ALBUM_NAME) ?: "",
             homeAlbumName = settingsDataStoreImpl.getString(SettingsConstants.HOME_ALBUM_NAME) ?: "",
             shuffle = settingsDataStoreImpl.getBoolean(SettingsConstants.SHUFFLE) ?: true,
-            skipLandscape = settingsDataStoreImpl.getBoolean(SettingsConstants.SKIP_LANDSCAPE) ?: false
+            skipLandscape = settingsDataStoreImpl.getBoolean(SettingsConstants.SKIP_LANDSCAPE) ?: false,
+            skipNonInteractive = settingsDataStoreImpl.getBoolean(SettingsConstants.SKIP_NON_INTERACTIVE) ?: false
         )
     }
 
@@ -157,6 +159,16 @@ class LockWallpaperService: Service() {
                 Log.d("PaperizeWallpaperChanger", "Skipping wallpaper change - device is in landscape mode")
                 onDestroy()
                 return
+            }
+
+            if (settings.skipNonInteractive){
+                val powerManager = context.getSystemService(POWER_SERVICE) as PowerManager
+                if (!powerManager.isInteractive){
+                    Log.d(
+                        "PaperizeWallpaperChanger", "Skipping wallpaper change - device is in non-interactive state")
+                    onDestroy()
+                    return
+                }
             }
 
             val lockAlbum = selectedAlbum.find { it.album.initialAlbumName == settings.lockAlbumName }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
   <string name="interval_text">Time Interval</string>
   <string name="change_blur">Blur Effect</string>
   <string name="skip_landscape_mode">Skip in landscape mode</string>
+  <string name="skip_non_interactive_state">Skip in non-interactive state</string>
   <string name="paperize_is_running">Paperize is running</string>
   <string name="next_wallpaper_change">Next wallpaper change: %1$s</string>
   <string name="delay_notice">Delay Notice</string>
@@ -192,5 +193,6 @@
   <string name="make_the_colors_grayscale">Make the colors grayscale</string>
   <string name="shuffle_the_wallpapers">Shuffle the wallpapers</string>
   <string name="prevent_changing_during_landscape_mode">Prevent changing during landscape mode</string>
+  <string name="prevent_changing_during_non_interactive_state">Prevent changing during non-interactive\nstate (e.g. Screen is off)</string>
   <string name="changing_wallpaper">Changing wallpaper…</string>
 </resources>


### PR DESCRIPTION
On some devices that support full-screen AOD, such as Xiaomi 15, changing the wallpaper when the screen is in AOD mode will cause the display turn into black. So I made this feature as a workaround solution.

Just thinking that this also might be useful when sometimes, so I do this PR.