### PR TITLE
fix: enable large collections through larger cursor window

### DIFF
--- a/app/src/main/java/com/anthonyla/paperize/App.kt
+++ b/app/src/main/java/com/anthonyla/paperize/App.kt
@@ -16,6 +16,24 @@ import java.lang.reflect.Field
 class App: Application() {
     override fun onCreate() {
         super.onCreate()
+
+        // Increase CursorWindow size to handle large datasets
+        // Default is usually 2MB, increasing to 10MB
+        try {
+            val field: Field = CursorWindow::class.java.getDeclaredField("sCursorWindowSize")
+            field.isAccessible = true
+            field.set(null, 10 * 1024 * 1024) // 10MB
+        } catch (e: Exception) {
+            // Fallback for newer Android versions where field might be different
+            try {
+                val field: Field = CursorWindow::class.java.getDeclaredField("CURSOR_WINDOW_SIZE")
+                field.isAccessible = true
+                field.set(null, 10 * 1024 * 1024) // 10MB
+            } catch (e2: Exception) {
+                e2.printStackTrace()
+            }
+        }
+
         val channel = NotificationChannel("wallpaper_service_channel", "Paperize", NotificationManager.IMPORTANCE_LOW)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)


### PR DESCRIPTION
closes #372

I compiled & tested this ugly fix: it solves #372. App now works for me with 15k images instead of crashing with 9k.

A rework of the data handling is still recommended as serializing large data structures and storing as json in sqlite is not ideal.