### PR TITLE
fix: restore compilation — remove orphaned onNavigateToSort call site

### DIFF
--- a/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
@@ -165,7 +165,7 @@ fun NavigationGraph(
             popEnterTransition = enterBackward,
             popExitTransition = exitBackward
         ) { backStackEntry ->
-            val route = backStackEntry.toRoute<AlbumRoute>()
+            backStackEntry.toRoute<AlbumRoute>()
             AlbumViewScreen(
                 onBackClick = { navController.popBackStack() },
                 onNavigateToFolder = { folderId ->
@@ -173,9 +173,6 @@ fun NavigationGraph(
                 },
                 onNavigateToWallpaperView = { wallpaperUri, wallpaperName ->
                     navController.navigate(WallpaperViewRoute(wallpaperUri, wallpaperName))
-                },
-                onNavigateToSort = {
-                    navController.navigate(SortRoute(route.albumId))
                 }
             )
         }


### PR DESCRIPTION
`master` has not compiled since `bc26d3c` (2026-03-25): album sorting moved to an inline `SortBottomSheet` and `AlbumViewScreen` dropped its `onNavigateToSort` parameter, but `NavigationGraph` still passes it — so `compileDebugKotlin` fails with *No parameter with name 'onNavigateToSort'*. Every CI run has been red at the unit-test step since then (it fails at compile, before any test).

This removes the orphaned argument (and the now-unused `route` binding). One file, +1/−4. `./gradlew compileDebugKotlin` and `testDebugUnitTest` pass.

Note: the `screens/sort/` package + `SortRoute` are now dead code; happy to remove them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)