### PR TITLE
feat: show live import progress when adding folders/wallpapers

### DIFF
--- a/app/src/main/java/com/anthonyla/paperize/core/util/Extensions.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/util/Extensions.kt
@@ -58,8 +58,11 @@ data class ScannedImage(
  *
  * Returned URIs are built from the same tree document id used by [DocumentFile], so they
  * are byte-for-byte identical to the previous implementation and remain stable across the app.
+ *
+ * [onProgress] is invoked with the running number of images found, throttled to roughly once
+ * per [PROGRESS_REPORT_INTERVAL] discoveries so callers can show a live count without flooding.
  */
-fun Uri.scanFolderImages(context: Context): List<ScannedImage> {
+fun Uri.scanFolderImages(context: Context, onProgress: ((found: Int) -> Unit)? = null): List<ScannedImage> {
     val rootDocumentId = try {
         DocumentsContract.getTreeDocumentId(this)
     } catch (_: IllegalArgumentException) {
@@ -74,6 +77,7 @@ fun Uri.scanFolderImages(context: Context): List<ScannedImage> {
     )
 
     val results = mutableListOf<ScannedImage>()
+    var lastReported = 0
     val pendingDirs = ArrayDeque<String>()
     pendingDirs.addLast(rootDocumentId)
 
@@ -102,6 +106,10 @@ fun Uri.scanFolderImages(context: Context): List<ScannedImage> {
                                     lastModified = if (cursor.isNull(modifiedColumn)) 0L else cursor.getLong(modifiedColumn)
                                 )
                             )
+                            if (onProgress != null && results.size - lastReported >= PROGRESS_REPORT_INTERVAL) {
+                                lastReported = results.size
+                                onProgress(results.size)
+                            }
                         }
                     }
                 }
@@ -110,8 +118,12 @@ fun Uri.scanFolderImages(context: Context): List<ScannedImage> {
             // Skip directories that can't be read and continue with the rest of the tree.
         }
     }
+    onProgress?.invoke(results.size)
     return results
 }
+
+/** Report scan progress at most once per this many discovered images. */
+private const val PROGRESS_REPORT_INTERVAL = 512
 
 /**
  * UUID generation

--- a/app/src/main/java/com/anthonyla/paperize/core/util/Extensions.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/util/Extensions.kt
@@ -3,7 +3,9 @@ package com.anthonyla.paperize.core.util
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
+import com.anthonyla.paperize.core.constants.Constants
 import java.util.UUID
 
 /**
@@ -34,30 +36,81 @@ fun Uri.getFileName(context: Context): String? {
 }
 
 /**
- * Scan a folder URI and return all image file URIs
+ * One image file discovered while scanning a folder tree.
+ *
+ * [name] and [lastModified] are read from the same cursor row as [uri], so callers
+ * do not need a follow-up per-file query to obtain them.
  */
-fun Uri.scanFolderForImages(context: Context): List<Uri> {
-    val documentFile = DocumentFile.fromTreeUri(context, this) ?: return emptyList()
-    if (!documentFile.isDirectory) return emptyList()
+data class ScannedImage(
+    val uri: Uri,
+    val name: String,
+    val lastModified: Long
+)
 
-    val imageUris = mutableListOf<Uri>()
+/**
+ * Recursively scan a tree [Uri] for image files.
+ *
+ * Uses a single [DocumentsContract] cursor query per directory instead of
+ * [DocumentFile.listFiles], which issues a separate IPC round-trip for every file and
+ * for every attribute access (name, isDirectory, lastModified). For folders with tens of
+ * thousands of files that difference is the dominant cost. Directories are traversed
+ * iteratively to avoid deep-recursion stack overflow on heavily nested trees.
+ *
+ * Returned URIs are built from the same tree document id used by [DocumentFile], so they
+ * are byte-for-byte identical to the previous implementation and remain stable across the app.
+ */
+fun Uri.scanFolderImages(context: Context): List<ScannedImage> {
+    val rootDocumentId = try {
+        DocumentsContract.getTreeDocumentId(this)
+    } catch (_: IllegalArgumentException) {
+        return emptyList() // Not a tree URI
+    }
 
-    fun scanDirectory(directory: DocumentFile) {
-        directory.listFiles().forEach { file ->
-            when {
-                file.isDirectory -> scanDirectory(file) // Recursively scan subdirectories
-                file.isFile -> {
-                    val ext = file.name?.substringAfterLast('.', "")?.lowercase() ?: ""
-                    if (ext in com.anthonyla.paperize.core.constants.Constants.SUPPORTED_IMAGE_EXTENSIONS) {
-                        imageUris.add(file.uri)
+    val projection = arrayOf(
+        DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+        DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+        DocumentsContract.Document.COLUMN_MIME_TYPE,
+        DocumentsContract.Document.COLUMN_LAST_MODIFIED
+    )
+
+    val results = mutableListOf<ScannedImage>()
+    val pendingDirs = ArrayDeque<String>()
+    pendingDirs.addLast(rootDocumentId)
+
+    while (pendingDirs.isNotEmpty()) {
+        val parentDocumentId = pendingDirs.removeLast()
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(this, parentDocumentId)
+        try {
+            context.contentResolver.query(childrenUri, projection, null, null, null)?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+                val nameColumn = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+                val mimeColumn = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_MIME_TYPE)
+                val modifiedColumn = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_LAST_MODIFIED)
+
+                while (cursor.moveToNext()) {
+                    val documentId = cursor.getString(idColumn) ?: continue
+                    if (cursor.getString(mimeColumn) == DocumentsContract.Document.MIME_TYPE_DIR) {
+                        pendingDirs.addLast(documentId)
+                    } else {
+                        val name = cursor.getString(nameColumn) ?: continue
+                        val extension = name.substringAfterLast('.', "").lowercase()
+                        if (extension in Constants.SUPPORTED_IMAGE_EXTENSIONS) {
+                            results.add(
+                                ScannedImage(
+                                    uri = DocumentsContract.buildDocumentUriUsingTree(this, documentId),
+                                    name = name,
+                                    lastModified = if (cursor.isNull(modifiedColumn)) 0L else cursor.getLong(modifiedColumn)
+                                )
+                            )
+                        }
                     }
                 }
             }
+        } catch (_: Exception) {
+            // Skip directories that can't be read and continue with the rest of the tree.
         }
     }
-
-    scanDirectory(documentFile)
-    return imageUris.sortedBy { it.toString() } // Sort for consistency
+    return results
 }
 
 /**

--- a/app/src/main/java/com/anthonyla/paperize/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/anthonyla/paperize/data/repository/AlbumRepositoryImpl.kt
@@ -43,6 +43,11 @@ class AlbumRepositoryImpl @Inject constructor(
     private val wallpaperRepository: dagger.Lazy<com.anthonyla.paperize.domain.repository.WallpaperRepository>
 ) : AlbumRepository {
 
+    companion object {
+        /** Number of wallpapers written per insert/progress step during an import. */
+        private const val WALLPAPER_INSERT_CHUNK_SIZE = 500
+    }
+
     override fun getAlbumSummaries(): Flow<List<AlbumSummary>> =
         albumDao.getAlbumSummaries().map { it.toDomainModelsFromSummaries() }
 
@@ -115,12 +120,13 @@ class AlbumRepositoryImpl @Inject constructor(
 
     override suspend fun addWallpapersToAlbum(
         albumId: String,
-        wallpapers: List<Wallpaper>
+        wallpapers: List<Wallpaper>,
+        onProgress: (saved: Int, total: Int) -> Unit
     ): Result<Unit> {
         return try {
             // Atomic transaction - insert wallpapers, update timestamp, and update cover
             database.withTransaction {
-                wallpaperDao.insertWallpapers(wallpapers.toEntities())
+                insertWallpapersChunked(wallpapers, onProgress)
                 albumDao.updateAlbumModifiedTime(albumId, System.currentTimeMillis())
 
                 // Update album cover if it doesn't have one
@@ -132,13 +138,17 @@ class AlbumRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun addFolderToAlbum(albumId: String, folder: Folder): Result<Unit> {
+    override suspend fun addFolderToAlbum(
+        albumId: String,
+        folder: Folder,
+        onProgress: (saved: Int, total: Int) -> Unit
+    ): Result<Unit> {
         return try {
             // Atomic transaction - folder, wallpapers, timestamp, and cover all succeed or all fail
             database.withTransaction {
                 folderDao.insertFolder(folder.toEntity())
                 // Insert folder wallpapers
-                wallpaperDao.insertWallpapers(folder.wallpapers.toEntities())
+                insertWallpapersChunked(folder.wallpapers, onProgress)
                 albumDao.updateAlbumModifiedTime(albumId, System.currentTimeMillis())
 
                 // Update album cover if it doesn't have one
@@ -147,6 +157,24 @@ class AlbumRepositoryImpl @Inject constructor(
             Result.Success(Unit)
         } catch (e: Exception) {
             Result.Error(e)
+        }
+    }
+
+    /**
+     * Insert [wallpapers] in chunks, mapping each chunk to entities only as it is written so the
+     * full entity list is never materialized at once, and reporting progress after each chunk.
+     * Must be called inside a transaction so the overall insert stays atomic.
+     */
+    private suspend fun insertWallpapersChunked(
+        wallpapers: List<Wallpaper>,
+        onProgress: (saved: Int, total: Int) -> Unit
+    ) {
+        val total = wallpapers.size
+        var saved = 0
+        wallpapers.chunked(WALLPAPER_INSERT_CHUNK_SIZE).forEach { chunk ->
+            wallpaperDao.insertWallpapers(chunk.toEntities())
+            saved += chunk.size
+            onProgress(saved, total)
         }
     }
 

--- a/app/src/main/java/com/anthonyla/paperize/data/repository/WallpaperRepositoryImpl.kt
+++ b/app/src/main/java/com/anthonyla/paperize/data/repository/WallpaperRepositoryImpl.kt
@@ -4,13 +4,12 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import androidx.core.net.toUri
-import androidx.documentfile.provider.DocumentFile
 import com.anthonyla.paperize.core.Result
 import com.anthonyla.paperize.core.ScreenType
 import com.anthonyla.paperize.core.WallpaperSourceType
-import com.anthonyla.paperize.core.constants.Constants
 import com.anthonyla.paperize.core.util.generateId
 import com.anthonyla.paperize.core.util.isValid
+import com.anthonyla.paperize.core.util.scanFolderImages
 import com.anthonyla.paperize.data.database.dao.WallpaperCurrentDao
 import com.anthonyla.paperize.data.database.dao.WallpaperDao
 import com.anthonyla.paperize.data.database.dao.WallpaperQueueDao
@@ -261,49 +260,21 @@ class WallpaperRepositoryImpl @Inject constructor(
 
     override suspend fun scanFolderForWallpapers(folderUri: Uri): Result<List<Wallpaper>> {
         return try {
-            val documentFile = DocumentFile.fromTreeUri(context, folderUri)
-                ?: return Result.Error(Exception("Invalid folder URI"))
-
-            val wallpapers = mutableListOf<Wallpaper>()
-            scanDirectoryRecursive(documentFile, wallpapers)
-
+            val wallpapers = folderUri.scanFolderImages(context).map { image ->
+                Wallpaper(
+                    id = generateId(),
+                    albumId = "",
+                    folderId = null,
+                    uri = image.uri.toString(),
+                    fileName = image.name,
+                    dateModified = image.lastModified,
+                    sourceType = WallpaperSourceType.FOLDER
+                )
+            }
             Result.Success(wallpapers)
         } catch (e: Exception) {
             Result.Error(e)
         }
-    }
-
-    private fun scanDirectoryRecursive(directory: DocumentFile, result: MutableList<Wallpaper>) {
-        directory.listFiles().forEach { file ->
-            if (file.isDirectory) {
-                scanDirectoryRecursive(file, result)
-            } else if (file.isFile && file.name?.let { name -> isImageFile(name) } == true) {
-                try {
-                    val uri = file.uri.toString()
-                    val fileName = file.name ?: return@forEach
-                    val dateModified = file.lastModified()
-
-                    result.add(
-                        Wallpaper(
-                            id = generateId(),
-                            albumId = "", 
-                            folderId = null,
-                            uri = uri,
-                            fileName = fileName,
-                            dateModified = dateModified,
-                            sourceType = WallpaperSourceType.FOLDER
-                        )
-                    )
-                } catch (_: Exception) {
-                    // Skip failed items
-                }
-            }
-        }
-    }
-
-    private fun isImageFile(fileName: String): Boolean {
-        val extension = fileName.substringAfterLast('.', "").lowercase()
-        return extension in Constants.SUPPORTED_IMAGE_EXTENSIONS
     }
 
     override suspend fun isWallpaperInAlbum(albumId: String, uri: String): Boolean =

--- a/app/src/main/java/com/anthonyla/paperize/domain/repository/AlbumRepository.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/repository/AlbumRepository.kt
@@ -64,17 +64,28 @@ interface AlbumRepository {
     suspend fun updateAlbumCover(albumId: String, coverUri: String?): Result<Unit>
 
     /**
-     * Add wallpapers to album
+     * Add wallpapers to album.
+     *
+     * [onProgress] is invoked as rows are written, with the number saved so far and the total,
+     * so callers can show import progress.
      */
     suspend fun addWallpapersToAlbum(
         albumId: String,
-        wallpapers: List<Wallpaper>
+        wallpapers: List<Wallpaper>,
+        onProgress: (saved: Int, total: Int) -> Unit = { _, _ -> }
     ): Result<Unit>
 
     /**
-     * Add folder to album
+     * Add folder to album.
+     *
+     * [onProgress] is invoked as the folder's wallpapers are written, with the number saved so far
+     * and the total, so callers can show import progress.
      */
-    suspend fun addFolderToAlbum(albumId: String, folder: Folder): Result<Unit>
+    suspend fun addFolderToAlbum(
+        albumId: String,
+        folder: Folder,
+        onProgress: (saved: Int, total: Int) -> Unit = { _, _ -> }
+    ): Result<Unit>
 
     /**
      * Update folder

--- a/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
@@ -165,7 +165,7 @@ fun NavigationGraph(
             popEnterTransition = enterBackward,
             popExitTransition = exitBackward
         ) { backStackEntry ->
-            val route = backStackEntry.toRoute<AlbumRoute>()
+            backStackEntry.toRoute<AlbumRoute>()
             AlbumViewScreen(
                 onBackClick = { navController.popBackStack() },
                 onNavigateToFolder = { folderId ->
@@ -173,9 +173,6 @@ fun NavigationGraph(
                 },
                 onNavigateToWallpaperView = { wallpaperUri, wallpaperName ->
                     navController.navigate(WallpaperViewRoute(wallpaperUri, wallpaperName))
-                },
-                onNavigateToSort = {
-                    navController.navigate(SortRoute(route.albumId))
                 }
             )
         }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewScreen.kt
@@ -37,6 +37,7 @@ import com.anthonyla.paperize.core.constants.Constants
 import com.anthonyla.paperize.presentation.common.components.AddAlbumAnimatedFab
 import com.anthonyla.paperize.presentation.screens.album_view.components.AlbumViewTopBar
 import com.anthonyla.paperize.presentation.screens.album_view.components.FolderItem
+import com.anthonyla.paperize.presentation.screens.album_view.components.ImportProgressDialog
 import com.anthonyla.paperize.presentation.screens.album_view.components.SortBottomSheet
 import com.anthonyla.paperize.presentation.screens.album_view.components.SortOption
 import com.anthonyla.paperize.presentation.screens.album_view.components.WallpaperItem
@@ -62,6 +63,7 @@ fun AlbumViewScreen(
     val selectedWallpapers by viewModel.selectedWallpapers.collectAsStateWithLifecycle()
     val selectedFolders by viewModel.selectedFolders.collectAsStateWithLifecycle()
     val isSelectionMode by viewModel.isSelectionMode.collectAsStateWithLifecycle()
+    val importProgress by viewModel.importProgress.collectAsStateWithLifecycle()
     val selectedCount = selectedWallpapers.size + selectedFolders.size
 
     // Check if all items are selected
@@ -157,7 +159,7 @@ fun AlbumViewScreen(
             // Hide FAB when in selection mode
             if (!isSelectionMode) {
                 AddAlbumAnimatedFab(
-                    isLoading = false,
+                    isLoading = importProgress !is ImportProgress.Idle,
                     onImageClick = { imagePickerLauncher.launch(arrayOf("image/*")) },
                     onFolderClick = { folderPickerLauncher.launch(null) }
                 )
@@ -247,6 +249,9 @@ fun AlbumViewScreen(
             onDismiss = { showSortSheet = false }
         )
     }
+
+    // Import progress (add folder / add wallpapers)
+    ImportProgressDialog(progress = importProgress)
 
     // Delete Album Confirmation Dialog
     if (showDeleteAlbumDialog) {

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewViewModel.kt
@@ -80,8 +80,12 @@ class AlbumViewViewModel @Inject constructor(
     private val _isSelectionMode = MutableStateFlow(false)
     val isSelectionMode: StateFlow<Boolean> = _isSelectionMode.asStateFlow()
 
+    private val _importProgress = MutableStateFlow<ImportProgress>(ImportProgress.Idle)
+    val importProgress: StateFlow<ImportProgress> = _importProgress.asStateFlow()
+
     fun addWallpapers(uris: List<String>) {
         viewModelScope.launch {
+            _importProgress.value = ImportProgress.Saving(saved = 0, total = uris.size)
             val existingCount = wallpapers.value.size
             val newWallpapers = uris.mapIndexed { index, uri ->
                 val parsedUri = uri.toUri()
@@ -98,7 +102,10 @@ class AlbumViewViewModel @Inject constructor(
                     mediaType = mediaType
                 )
             }
-            when (val result = albumRepository.addWallpapersToAlbum(albumId, newWallpapers)) {
+            val result = albumRepository.addWallpapersToAlbum(albumId, newWallpapers) { saved, total ->
+                _importProgress.value = ImportProgress.Saving(saved, total)
+            }
+            when (result) {
                 is com.anthonyla.paperize.core.Result.Success -> {
                     // Clear queues so the new wallpapers are included on the next cycle
                     wallpaperRepository.clearQueuesForAlbum(albumId)
@@ -108,15 +115,19 @@ class AlbumViewViewModel @Inject constructor(
                 }
                 is com.anthonyla.paperize.core.Result.Loading -> { /* Loading state not used */ }
             }
+            _importProgress.value = ImportProgress.Idle
         }
     }
 
     fun addFolder(uri: String) {
         viewModelScope.launch {
+            _importProgress.value = ImportProgress.Scanning(found = 0)
             // Scan folder for images on IO dispatcher. The scan already returns each file's
             // name and modified time, so no per-file follow-up query is needed below.
             val images = withContext(Dispatchers.IO) {
-                uri.toUri().scanFolderImages(context).sortedBy { it.uri.toString() }
+                uri.toUri().scanFolderImages(context) { found ->
+                    _importProgress.value = ImportProgress.Scanning(found)
+                }.sortedBy { it.uri.toString() }
             }
 
             // Create folder with scanned wallpapers
@@ -133,6 +144,7 @@ class AlbumViewViewModel @Inject constructor(
                     mediaType = WallpaperMediaType.fromExtension(image.name.substringAfterLast('.', "")) ?: WallpaperMediaType.IMAGE
                 )
             }
+            _importProgress.value = ImportProgress.Saving(saved = 0, total = wallpapers.size)
 
             val folder = Folder(
                 id = folderId,
@@ -145,7 +157,10 @@ class AlbumViewViewModel @Inject constructor(
                 wallpapers = wallpapers
             )
 
-            when (val result = albumRepository.addFolderToAlbum(albumId, folder)) {
+            val result = albumRepository.addFolderToAlbum(albumId, folder) { saved, total ->
+                _importProgress.value = ImportProgress.Saving(saved, total)
+            }
+            when (result) {
                 is com.anthonyla.paperize.core.Result.Success -> {
                     // Clear queues so the new folder's wallpapers are included on the next cycle
                     wallpaperRepository.clearQueuesForAlbum(albumId)
@@ -155,6 +170,7 @@ class AlbumViewViewModel @Inject constructor(
                 }
                 is com.anthonyla.paperize.core.Result.Loading -> { /* Loading state not used */ }
             }
+            _importProgress.value = ImportProgress.Idle
         }
     }
 

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewViewModel.kt
@@ -11,7 +11,7 @@ import androidx.navigation.toRoute
 import com.anthonyla.paperize.core.util.detectMediaType
 import com.anthonyla.paperize.core.util.generateId
 import com.anthonyla.paperize.core.util.getFileName
-import com.anthonyla.paperize.core.util.scanFolderForImages
+import com.anthonyla.paperize.core.util.scanFolderImages
 import com.anthonyla.paperize.core.WallpaperMediaType
 import com.anthonyla.paperize.domain.model.Album
 import com.anthonyla.paperize.domain.model.Folder
@@ -113,25 +113,24 @@ class AlbumViewViewModel @Inject constructor(
 
     fun addFolder(uri: String) {
         viewModelScope.launch {
-            // Scan folder for images on IO dispatcher
-            val imageUris = withContext(Dispatchers.IO) {
-                uri.toUri().scanFolderForImages(context)
+            // Scan folder for images on IO dispatcher. The scan already returns each file's
+            // name and modified time, so no per-file follow-up query is needed below.
+            val images = withContext(Dispatchers.IO) {
+                uri.toUri().scanFolderImages(context).sortedBy { it.uri.toString() }
             }
 
             // Create folder with scanned wallpapers
             val folderId = generateId()
-            val wallpapers = imageUris.mapIndexed { index, imageUri ->
-                val mediaType = imageUri.detectMediaType(context) ?: WallpaperMediaType.IMAGE
-
+            val wallpapers = images.mapIndexed { index, image ->
                 Wallpaper(
                     id = generateId(),
                     albumId = albumId,
                     folderId = folderId,
-                    uri = imageUri.toString(),
-                    fileName = imageUri.getFileName(context) ?: imageUri.lastPathSegment ?: imageUri.toString().substringAfterLast('/'),
-                    dateModified = System.currentTimeMillis(),
+                    uri = image.uri.toString(),
+                    fileName = image.name,
+                    dateModified = image.lastModified,
                     displayOrder = index,
-                    mediaType = mediaType
+                    mediaType = WallpaperMediaType.fromExtension(image.name.substringAfterLast('.', "")) ?: WallpaperMediaType.IMAGE
                 )
             }
 

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/ImportProgress.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/ImportProgress.kt
@@ -1,0 +1,16 @@
+package com.anthonyla.paperize.presentation.screens.album_view
+
+/**
+ * Progress of an ongoing add-folder / add-wallpapers import, surfaced to the UI so it can
+ * show a live count instead of a bare spinner.
+ */
+sealed interface ImportProgress {
+    /** No import running. */
+    data object Idle : ImportProgress
+
+    /** Walking the folder tree; the total is not yet known. */
+    data class Scanning(val found: Int) : ImportProgress
+
+    /** Writing the discovered images to the database. */
+    data class Saving(val saved: Int, val total: Int) : ImportProgress
+}

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/components/ImportProgressDialog.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/components/ImportProgressDialog.kt
@@ -1,0 +1,99 @@
+package com.anthonyla.paperize.presentation.screens.album_view.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.anthonyla.paperize.R
+import com.anthonyla.paperize.presentation.screens.album_view.ImportProgress
+
+/**
+ * Non-dismissable modal shown while a folder/wallpaper import is running, displaying a live count
+ * (and a determinate bar once the total is known) instead of a bare spinner.
+ *
+ * Renders nothing when [progress] is [ImportProgress.Idle].
+ */
+@Composable
+fun ImportProgressDialog(progress: ImportProgress) {
+    if (progress is ImportProgress.Idle) return
+
+    Dialog(
+        onDismissRequest = { /* Block dismissal while importing */ },
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                val titleRes = when (progress) {
+                    is ImportProgress.Scanning -> R.string.import_adding_folder
+                    else -> R.string.import_adding_wallpapers
+                }
+                Text(
+                    text = stringResource(titleRes),
+                    style = MaterialTheme.typography.titleMedium
+                )
+
+                when (progress) {
+                    is ImportProgress.Scanning -> {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                            Text(
+                                text = stringResource(R.string.import_scanning, progress.found),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
+                    is ImportProgress.Saving -> {
+                        Text(
+                            text = stringResource(R.string.import_saving, progress.saved, progress.total),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        val fraction by animateFloatAsState(
+                            targetValue = if (progress.total > 0) progress.saved.toFloat() / progress.total else 0f,
+                            label = "importProgress"
+                        )
+                        LinearProgressIndicator(
+                            progress = { fraction },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(6.dp)
+                        )
+                    }
+
+                    ImportProgress.Idle -> Unit // unreachable, guarded above
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Paperize</string>
+  <string name="import_adding_folder">Adding folder…</string>
+  <string name="import_adding_wallpapers">Adding wallpapers…</string>
+  <string name="import_scanning">Scanning… %1$d found</string>
+  <string name="import_saving">Saving %1$d / %2$d</string>
   <string name="home">Home</string>
   <string name="settings_screen">Settings</string>
   <string name="wallpaper">Wallpaper</string>


### PR DESCRIPTION
Adding a large folder gave no feedback at all (the FAB's `isLoading` hook was hardcoded `false`), so a long import looked frozen.

This surfaces an `ImportProgress` state from `AlbumViewViewModel` and shows a modal dialog with a live count: a counting-up *Scanning… N found* during the folder walk, then a determinate *Saving X / total* bar while rows are written. `scanFolderImages` reports discovery progress (throttled), and inserts run in chunks that report saved/total — which also avoids materializing the full entity list at once.

Depends on #535 (folder scanner) — built on top of it; CI green here includes #534 + #535. Will rebase as those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)