### PR TITLE
feat: 'change wallpaper now' button + non-scrolling home option

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
+    <!-- Required by WallpaperManager.suggestDesiredDimensions() (non-scrolling home option). Normal-level, auto-granted. -->
+    <uses-permission android:name="android.permission.SET_WALLPAPER_HINTS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/com/anthonyla/paperize/core/constants/Constants.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/constants/Constants.kt
@@ -195,6 +195,7 @@ object PreferenceKeys {
     const val HOME_SCALING_TYPE = "home_scaling_type"
     const val LOCK_SCALING_TYPE = "lock_scaling_type"
     const val LIVE_SCALING_TYPE = "live_scaling_type"
+    const val HOME_SCROLLING_ENABLED = "home_scrolling_enabled"
 
     // Behavior
     const val ADAPTIVE_BRIGHTNESS = "adaptive_brightness"

--- a/app/src/main/java/com/anthonyla/paperize/core/util/WallpaperUtil.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/util/WallpaperUtil.kt
@@ -143,36 +143,64 @@ fun getDeviceScreenSize(context: Context): Size {
     }
 }
 
+/** Width multiplier for the home parallax canvas when scrolling is enabled. */
+private const val HOME_PARALLAX_WIDTH_FACTOR = 2
+
 /**
  * Get the target render size for a wallpaper bitmap.
  *
- * For the HOME screen (and BOTH), the launcher may request a wider canvas than the physical
- * screen to support horizontal parallax scrolling across multiple home-screen pages (e.g.
- * Pixel Launcher with 3 pages requests ~3× screen width). If we render at physical-screen
- * width and pass a null visibleCropHint to WallpaperManager.setBitmap(), Android scales the
- * bitmap up to fill the launcher's desired width, which also enlarges the height and crops
- * the top/bottom — making "FIT" behave identically to "FILL" from the user's perspective.
+ * HOME/BOTH wallpapers are derived from the *actual* device screen size, not from
+ * WallpaperManager.getDesiredMinimumWidth/Height — the latter is a legacy value that on many
+ * modern devices reports a canvas unrelated to the real display (e.g. 4488×2244 on a portrait
+ * phone), which makes the launcher rescale/letterbox the bitmap into black bars.
  *
- * Fix: use WallpaperManager.getDesiredMinimumWidth/Height as the render target for HOME/BOTH
- * so the bitmap already fills the full parallax canvas. The launcher then has nothing to scale,
- * and the chosen scaling mode (FIT, FILL, STRETCH, NONE) is preserved correctly.
+ * - Scrolling enabled: a [HOME_PARALLAX_WIDTH_FACTOR]× wide canvas at full screen height, so the
+ *   launcher can pan across it for a normal parallax effect.
+ * - Scrolling disabled: exactly the physical screen size — a single-screen center-crop shown
+ *   identically on every page.
  *
- * LOCK screen wallpapers are not parallax-scrolled, so the physical screen size is correct.
- * LIVE wallpapers are rendered by GLRenderer directly; they do not go through this path.
+ * [applyHomeScrollPreference] feeds the same size to suggestDesiredDimensions() so the launcher
+ * canvas matches the bitmap 1:1. LOCK uses the physical screen; LIVE is rendered by the GL path.
  */
-fun getWallpaperRenderSize(context: Context, screenType: com.anthonyla.paperize.core.ScreenType): Size {
+fun getWallpaperRenderSize(
+    context: Context,
+    screenType: com.anthonyla.paperize.core.ScreenType,
+    homeScrollingEnabled: Boolean = true
+): Size {
     val screen = getDeviceScreenSize(context)
     return when (screenType) {
         com.anthonyla.paperize.core.ScreenType.HOME,
         com.anthonyla.paperize.core.ScreenType.BOTH -> {
-            val wm = WallpaperManager.getInstance(context)
-            val desiredW = wm.desiredMinimumWidth
-            val desiredH = wm.desiredMinimumHeight
-            // desiredMinimumWidth/Height return 0 when the launcher hasn't set a preference yet.
-            // Fall back to physical screen size in that case.
-            if (desiredW > 0 && desiredH > 0) Size(desiredW, desiredH) else screen
+            if (homeScrollingEnabled) {
+                Size(screen.width * HOME_PARALLAX_WIDTH_FACTOR, screen.height)
+            } else {
+                screen
+            }
         }
         else -> screen
+    }
+}
+
+/**
+ * Tell [WallpaperManager] what canvas size to expect for HOME/BOTH wallpapers, matching the size
+ * produced by [getWallpaperRenderSize] so the bitmap is shown 1:1 (no rescaling, no black bars).
+ *
+ * No-op for LOCK/LIVE, which are never parallax-scrolled through this path.
+ */
+fun applyHomeScrollPreference(
+    context: Context,
+    screenType: com.anthonyla.paperize.core.ScreenType,
+    homeScrollingEnabled: Boolean
+) {
+    if (screenType != com.anthonyla.paperize.core.ScreenType.HOME &&
+        screenType != com.anthonyla.paperize.core.ScreenType.BOTH
+    ) return
+    // Best-effort hint: never let a failure here abort the actual wallpaper change.
+    try {
+        val size = getWallpaperRenderSize(context, screenType, homeScrollingEnabled)
+        WallpaperManager.getInstance(context).suggestDesiredDimensions(size.width, size.height)
+    } catch (e: Exception) {
+        android.util.Log.w("WallpaperUtil", "suggestDesiredDimensions failed; continuing without scroll hint", e)
     }
 }
 

--- a/app/src/main/java/com/anthonyla/paperize/data/datastore/PreferencesManager.kt
+++ b/app/src/main/java/com/anthonyla/paperize/data/datastore/PreferencesManager.kt
@@ -125,6 +125,7 @@ class PreferencesManager @Inject constructor(
                 ?: Constants.DEFAULT_INTERVAL_MINUTES,
             homeScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE)]),
             lockScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE)]),
+            homeScrollingEnabled = prefs[booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED)] ?: true,
             liveScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE)]),
             homeEffects = WallpaperEffects(
                 enableBlur = prefs[booleanPreferencesKey(PreferenceKeys.HOME_ENABLE_BLUR)] ?: false,
@@ -188,6 +189,7 @@ class PreferencesManager @Inject constructor(
                 ?: Constants.DEFAULT_INTERVAL_MINUTES,
             homeScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE)]),
             lockScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE)]),
+            homeScrollingEnabled = prefs[booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED)] ?: true,
             liveScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE)]),
             homeEffects = WallpaperEffects(
                 enableBlur = prefs[booleanPreferencesKey(PreferenceKeys.HOME_ENABLE_BLUR)] ?: false,
@@ -260,6 +262,7 @@ class PreferencesManager @Inject constructor(
             prefs[intPreferencesKey(PreferenceKeys.LIVE_INTERVAL_MINUTES)] = settings.liveIntervalMinutes
             prefs[stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE)] = settings.homeScalingType.name
             prefs[stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE)] = settings.lockScalingType.name
+            prefs[booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED)] = settings.homeScrollingEnabled
             prefs[stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE)] = settings.liveScalingType.name
 
             // Home effects
@@ -524,6 +527,7 @@ class PreferencesManager @Inject constructor(
             prefs.remove(stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE))
             prefs.remove(stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE))
             prefs.remove(stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE))
+            prefs.remove(booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED))
 
             // Clear adaptive brightness
             prefs.remove(booleanPreferencesKey(PreferenceKeys.ADAPTIVE_BRIGHTNESS))

--- a/app/src/main/java/com/anthonyla/paperize/domain/model/ScheduleSettings.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/model/ScheduleSettings.kt
@@ -19,6 +19,8 @@ data class ScheduleSettings(
     val liveIntervalMinutes: Int = Constants.DEFAULT_INTERVAL_MINUTES,
     val homeScalingType: ScalingType = ScalingType.FILL,
     val lockScalingType: ScalingType = ScalingType.FILL,
+    /** When false, the home wallpaper is rendered at single-screen size and not parallax-scrolled. */
+    val homeScrollingEnabled: Boolean = true,
     val homeEffects: WallpaperEffects = WallpaperEffects.none(),
     val lockEffects: WallpaperEffects = WallpaperEffects.none(),
     val liveAlbumId: String? = null,
@@ -67,6 +69,7 @@ data class ScheduleSettings(
     fun hasDisplayChanges(other: ScheduleSettings): Boolean {
         return homeScalingType != other.homeScalingType ||
                lockScalingType != other.lockScalingType ||
+               homeScrollingEnabled != other.homeScrollingEnabled ||
                homeEffects != other.homeEffects ||
                lockEffects != other.lockEffects ||
                liveEffects != other.liveEffects ||

--- a/app/src/main/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCase.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCase.kt
@@ -9,6 +9,7 @@ import com.anthonyla.paperize.core.NoValidWallpaperException
 import com.anthonyla.paperize.core.Result
 import com.anthonyla.paperize.core.ScreenType
 import com.anthonyla.paperize.core.util.adaptiveBrightnessAdjustment
+import com.anthonyla.paperize.core.util.applyHomeScrollPreference
 import com.anthonyla.paperize.core.util.getWallpaperRenderSize
 import com.anthonyla.paperize.core.util.processBitmap
 import com.anthonyla.paperize.core.util.retrieveBitmap
@@ -55,9 +56,10 @@ class ChangeWallpaperUseCase @Inject constructor(
             var maxRetries = Constants.MAX_WALLPAPER_LOAD_RETRIES
             var queueRebuildAttempts = 0
 
-            // Get render dimensions once for the retry loop.
-            // HOME/BOTH use the launcher's desired parallax canvas; LOCK uses physical screen.
-            val screenSize = getWallpaperRenderSize(context, screenType)
+            // Get render dimensions once for the retry loop. HOME/BOTH use a screen-derived
+            // parallax canvas (or single screen when scrolling is disabled); LOCK uses physical screen.
+            applyHomeScrollPreference(context, screenType, settings.homeScrollingEnabled)
+            val screenSize = getWallpaperRenderSize(context, screenType, settings.homeScrollingEnabled)
             val effects = when (screenType) {
                 ScreenType.LIVE -> settings.liveEffects
                 ScreenType.HOME, ScreenType.BOTH -> settings.homeEffects
@@ -68,6 +70,11 @@ class ChangeWallpaperUseCase @Inject constructor(
                 ScreenType.HOME, ScreenType.BOTH -> settings.homeScalingType
                 ScreenType.LOCK -> settings.lockScalingType
             }
+            android.util.Log.d(
+                "ChangeWallpaperUseCase",
+                "render screen=$screenType scrolling=${settings.homeScrollingEnabled} " +
+                    "renderSize=${screenSize.width}x${screenSize.height} scaling=$scaling"
+            )
 
             while (finalBitmap == null && maxRetries > 0) {
                 val candidate = wallpaperRepository.getAndDequeueWallpaper(albumId, screenType)

--- a/app/src/main/java/com/anthonyla/paperize/domain/usecase/ReapplyEffectsUseCase.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/usecase/ReapplyEffectsUseCase.kt
@@ -7,6 +7,7 @@ import com.anthonyla.paperize.R
 import com.anthonyla.paperize.core.Result
 import com.anthonyla.paperize.core.ScreenType
 import com.anthonyla.paperize.core.util.adaptiveBrightnessAdjustment
+import com.anthonyla.paperize.core.util.applyHomeScrollPreference
 import com.anthonyla.paperize.core.util.getWallpaperRenderSize
 import com.anthonyla.paperize.core.util.isValid
 import com.anthonyla.paperize.core.util.processBitmap
@@ -36,7 +37,8 @@ class ReapplyEffectsUseCase @Inject constructor(
                 ?: return Result.Error(Exception(context.getString(R.string.error_no_valid_wallpaper_after_retries)))
 
             val settings = settingsRepository.getScheduleSettings()
-            val screenSize = getWallpaperRenderSize(context, screenType)
+            applyHomeScrollPreference(context, screenType, settings.homeScrollingEnabled)
+            val screenSize = getWallpaperRenderSize(context, screenType, settings.homeScrollingEnabled)
 
             val effects = when (screenType) {
                 ScreenType.LIVE -> settings.liveEffects

--- a/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
@@ -165,7 +165,7 @@ fun NavigationGraph(
             popEnterTransition = enterBackward,
             popExitTransition = exitBackward
         ) { backStackEntry ->
-            val route = backStackEntry.toRoute<AlbumRoute>()
+            backStackEntry.toRoute<AlbumRoute>()
             AlbumViewScreen(
                 onBackClick = { navController.popBackStack() },
                 onNavigateToFolder = { folderId ->
@@ -173,9 +173,6 @@ fun NavigationGraph(
                 },
                 onNavigateToWallpaperView = { wallpaperUri, wallpaperName ->
                     navController.navigate(WallpaperViewRoute(wallpaperUri, wallpaperName))
-                },
-                onNavigateToSort = {
-                    navController.navigate(SortRoute(route.albumId))
                 }
             )
         }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeScreen.kt
@@ -122,7 +122,8 @@ fun HomeScreen(
                                     onSelectLockAlbum = { album -> viewModel.selectLockAlbum(album) },
                                     onSelectLiveAlbum = { album -> viewModel.selectLiveAlbum(album) },
                                     onUpdateScheduleSettings = { viewModel.updateScheduleSettings(it) },
-                                    onUpdateScheduleSettingsDebounced = { viewModel.updateScheduleSettingsDebounced(it) }
+                                    onUpdateScheduleSettingsDebounced = { viewModel.updateScheduleSettingsDebounced(it) },
+                                    onChangeWallpaperNow = { viewModel.changeWallpaperNowForActiveScreens() }
                                 )
                             }
                         }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeViewModel.kt
@@ -438,6 +438,29 @@ class HomeViewModel @Inject constructor(
         context.startForegroundService(intent)
     }
 
+    /**
+     * Trigger an immediate wallpaper change for whichever screen(s) are currently active,
+     * mirroring the BOTH/HOME/LOCK split used when scheduling. Backs the manual "change now" button.
+     */
+    fun changeWallpaperNowForActiveScreens() {
+        val settings = scheduleSettings.value
+        if (wallpaperMode.value == com.anthonyla.paperize.core.WallpaperMode.LIVE) {
+            changeWallpaperNow(ScreenType.LIVE)
+            return
+        }
+        val homeActive = settings.homeEnabled && settings.homeAlbumId != null
+        val lockActive = settings.lockEnabled && settings.lockAlbumId != null
+        val isSynced = homeActive && lockActive &&
+            settings.homeAlbumId == settings.lockAlbumId && !settings.separateSchedules
+        when {
+            isSynced -> changeWallpaperNow(ScreenType.BOTH)
+            else -> {
+                if (homeActive) changeWallpaperNow(ScreenType.HOME)
+                if (lockActive) changeWallpaperNow(ScreenType.LOCK)
+            }
+        }
+    }
+
     fun reapplyEffectsNow(screenType: ScreenType) {
         val intent = Intent(context, WallpaperChangeService::class.java).apply {
             action = WallpaperChangeService.ACTION_REAPPLY_EFFECTS

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/WallpaperScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/WallpaperScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Button
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -70,6 +71,7 @@ fun WallpaperScreen(
     onSelectLiveAlbum: (AlbumSummary?) -> Unit,
     onUpdateScheduleSettings: (ScheduleSettings) -> Unit,
     onUpdateScheduleSettingsDebounced: (ScheduleSettings) -> Unit,
+    onChangeWallpaperNow: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var showAlbumSelectionSheet by rememberSaveable { mutableStateOf(false) }
@@ -623,6 +625,45 @@ fun WallpaperScreen(
                         }
                     }
                 }
+            }
+        }
+
+        // Don't-scroll toggle (static HOME only; LOCK never scrolls, LIVE has its own parallax)
+        if (wallpaperMode != WallpaperMode.LIVE && homeEnabled) {
+            Card(
+                shape = MaterialTheme.shapes.medium,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(PaddingValues(horizontal = AppSpacing.small, vertical = AppSpacing.extraSmall))
+            ) {
+                Column(
+                    modifier = Modifier.padding(AppSpacing.large),
+                    verticalArrangement = Arrangement.spacedBy(AppSpacing.medium)
+                ) {
+                    SettingSwitch(
+                        title = R.string.dont_scroll_home,
+                        description = R.string.dont_scroll_home_description,
+                        checked = !scheduleSettings.homeScrollingEnabled,
+                        onCheckedChange = { dontScroll ->
+                            updateSettingsImmediate(scheduleSettings.copy(homeScrollingEnabled = !dontScroll))
+                        }
+                    )
+                }
+            }
+        }
+
+        // Change wallpaper now
+        if (scheduleSettings.enableChanger) {
+            Button(
+                onClick = onChangeWallpaperNow,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(PaddingValues(horizontal = AppSpacing.small, vertical = AppSpacing.extraSmall))
+            ) {
+                Text(text = stringResource(R.string.change_wallpaper_now))
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Paperize</string>
+  <string name="change_wallpaper_now">Change wallpaper now</string>
+  <string name="dont_scroll_home">Don\'t scroll across home screens</string>
+  <string name="dont_scroll_home_description">Show the same centered wallpaper on every home screen page</string>
   <string name="home">Home</string>
   <string name="settings_screen">Settings</string>
   <string name="wallpaper">Wallpaper</string>


### PR DESCRIPTION
Two home-wallpaper UX changes:

**1. Change-now button** — the rewrite kept `HomeViewModel.changeWallpaperNow()` but dropped the in-app button (only the QS tile remained). Re-added to the wallpaper screen; triggers an immediate change for the active screen(s).

**2. Non-scrolling home option** — a per-home *Don't scroll across home screens* toggle. HOME/BOTH wallpapers are now sized from the **actual screen** (single screen when not scrolling; 2× width at full height for parallax when scrolling) instead of `WallpaperManager.getDesiredMinimumWidth/Height`, which on modern devices reports a canvas unrelated to the display (observed 4488×2244 on a portrait phone) that the launcher letterboxes into black bars. `suggestDesiredDimensions()` is fed the same size so the launcher shows the bitmap 1:1. Requires the normal-level `SET_WALLPAPER_HINTS` permission.

Tested on-device: the no-scroll path renders a clean centered crop; the scrolling path fills correctly (the old wide-canvas path showed a black gap + sliver of image).

Depends on #534 (compile fix) — included here for green CI; will rebase once #534 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)