### PR TITLE
ci: add Android-aware CodeQL analysis

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -27,6 +27,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   # ===================================================================
   # JOB: test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "24 6 * * 3"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze-actions:
+    name: Analyze GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository source code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          languages: actions
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+
+  analyze-java-kotlin:
+    name: Analyze Java and Kotlin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository source code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: "17"
+          distribution: temurin
+          cache: gradle
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build application for analysis
+        run: ./gradlew assembleDebug
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4


### PR DESCRIPTION
## Summary
- add CodeQL scanning for GitHub Actions and Java/Kotlin
- use a manual Android Gradle build because GitHub's default Java autobuild selects the nonexistent `testClasses` task
- pin every workflow action to an immutable commit
- run scans on pull requests, master pushes, and weekly
- make the existing release workflow token read-only by default, retaining write access only for the release job

## Validation
- normal unit CI passed
- CodeQL Actions and Java/Kotlin analysis both passed with the replacement workflow
- the initial scan identified two medium missing-permissions findings in the release workflow; this branch fixes both