### PR TITLE
fix: make notification intents explicitly targeted

### DIFF
--- a/app/src/main/java/com/anthonyla/paperize/service/wallpaper/WallpaperChangeService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/wallpaper/WallpaperChangeService.kt
@@ -358,7 +358,7 @@ class WallpaperChangeService : Service() {
         val pendingIntent = PendingIntent.getActivity(
             this,
             0,
-            Intent(this, MainActivity::class.java),
+            Intent().setClassName(packageName, MainActivity::class.java.name),
             PendingIntent.FLAG_IMMUTABLE
         )
         return NotificationCompat.Builder(this, Constants.NOTIFICATION_CHANNEL_ID)
@@ -374,7 +374,7 @@ class WallpaperChangeService : Service() {
         val pendingIntent = PendingIntent.getActivity(
             this,
             0,
-            Intent(this, MainActivity::class.java),
+            Intent().setClassName(packageName, MainActivity::class.java.name),
             PendingIntent.FLAG_IMMUTABLE
         )
         val notification = NotificationCompat.Builder(this, Constants.NOTIFICATION_CHANNEL_ID)


### PR DESCRIPTION
## Summary
- give both notification tap intents an explicit package/class destination
- retain immutable PendingIntent flags
- resolve the high-severity CodeQL implicit-PendingIntent finding with an analyzer-visible explicit component

## Validation
- `testDebugUnitTest` passed locally
- merge is gated on unit CI plus Actions and Java/Kotlin CodeQL analysis