### PR TITLE
Fix static wallpaper rendering and scheduling regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v4.0.3
+
+- Kept scheduled static changes in the device's natural orientation, even when a
+  landscape game or app is in the foreground.
+- Rendered FIT, FILL, STRETCH, and NONE against one physical display panel to fix
+  black canvases, excessive stretching, zoom, and inconsistent home/lock alignment.
+- Restored centered static FILL behavior by default and added an explicit horizontal
+  scrolling option for users who want wide wallpapers to move across home pages.
+- Added a persistent pause/resume control that keeps selected albums intact, while
+  leaving manual static and live wallpaper changes available when paused.
+- Removed the unnecessary network-state permission and unused network image loader.
+- Updated Hilt and the coroutine test library and expanded rotation, scaling,
+  scrolling, pause/resume, static-effect, live-renderer, and scheduler verification.
+
+**Full Changelog**: https://github.com/Anthonyy232/Paperize/compare/v4.0.2...v4.0.3
+
 ## v4.0.2
 
 - Reloaded the current live wallpaper at native resolution after fold, unfold,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.anthonyla.paperize"
         minSdk = 31
         targetSdk = 36
-        versionCode = 53
-        versionName = "4.0.2"
+        versionCode = 54
+        versionName = "4.0.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -95,7 +95,6 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.material)
     implementation(libs.coil.compose)
-    implementation(libs.coil.network.okhttp)
     implementation(libs.coil.gif)
     implementation(libs.coil.svg)
     implementation(libs.androidx.datastore)

--- a/app/src/androidTest/java/com/anthonyla/paperize/core/util/WallpaperUtilInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/anthonyla/paperize/core/util/WallpaperUtilInstrumentedTest.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.hardware.display.DisplayManager
 import android.net.Uri
 import android.os.Build
+import android.content.res.Configuration
 import androidx.exifinterface.media.ExifInterface
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -85,6 +86,27 @@ class WallpaperUtilInstrumentedTest {
     }
 
     @Test
+    fun everyStaticScalingModeProducesOneExactScreenCanvas() {
+        val image = createJpeg(width = 160, height = 90)
+
+        ScalingType.entries.forEach { scaling ->
+            val result = retrieveBitmap(
+                context = context,
+                wallpaperUri = Uri.fromFile(image),
+                width = 120,
+                height = 200,
+                scaling = scaling,
+                preserveSourceOverflow = false
+            )
+
+            assertNotNull("Expected a bitmap for $scaling", result)
+            assertEquals("Unexpected width for $scaling", 120, result?.width)
+            assertEquals("Unexpected height for $scaling", 200, result?.height)
+            result?.recycle()
+        }
+    }
+
+    @Test
     fun android17FoldableSizingIncludesInactiveBuiltInPanel() {
         assumeTrue(Build.VERSION.SDK_INT >= 37)
         val displayManager = context.getSystemService(DisplayManager::class.java)
@@ -105,6 +127,19 @@ class WallpaperUtilInstrumentedTest {
         assertNotNull(expected)
         assertEquals(expected?.first, actual.width)
         assertEquals(expected?.second, actual.height)
+    }
+
+    @Test
+    fun staticRenderSizeDoesNotRotateWithForegroundAppConfiguration() {
+        val landscapeConfiguration = Configuration(context.resources.configuration).apply {
+            orientation = Configuration.ORIENTATION_LANDSCAPE
+        }
+        val landscapeContext = context.createConfigurationContext(landscapeConfiguration)
+        val naturalPanel = ScreenMetricsCompat.getScreenSize(context)
+        val renderSize = getDeviceScreenSize(landscapeContext)
+
+        assertEquals(naturalPanel.width, renderSize.width)
+        assertEquals(naturalPanel.height, renderSize.height)
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- WorkManager contributes this permission for optional network constraints. Paperize never
+         schedules network-constrained work, so keep it out of the final manifest. -->
+    <uses-permission
+        android:name="android.permission.ACCESS_NETWORK_STATE"
+        tools:node="remove" />
     <!-- Features -->
     <uses-feature
         android:name="android.software.wallpaper"

--- a/app/src/main/java/com/anthonyla/paperize/core/constants/Constants.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/constants/Constants.kt
@@ -195,6 +195,7 @@ object PreferenceKeys {
     const val HOME_SCALING_TYPE = "home_scaling_type"
     const val LOCK_SCALING_TYPE = "lock_scaling_type"
     const val LIVE_SCALING_TYPE = "live_scaling_type"
+    const val HOME_SCROLLING_ENABLED = "home_scrolling_enabled"
 
     // Behavior
     const val ADAPTIVE_BRIGHTNESS = "adaptive_brightness"

--- a/app/src/main/java/com/anthonyla/paperize/core/util/WallpaperUtil.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/util/WallpaperUtil.kt
@@ -131,44 +131,48 @@ object ScreenMetricsCompat {
     fun getScreenSize(context: Context): Size {
         val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val metrics: WindowMetrics = windowManager.currentWindowMetrics
-        val candidates = buildList {
-            add(metrics.bounds.width() to metrics.bounds.height())
+        val currentWindow = metrics.bounds.width() to metrics.bounds.height()
 
-            // Foldables may expose the cover and inner panels as separate internal displays.
-            // Include every supported internal-display mode so a wallpaper changed while folded
-            // is still rendered sharply enough for the larger unfolded panel. External displays
-            // are deliberately excluded so a connected monitor cannot inflate wallpaper memory.
-            val displayManager = context.getSystemService(DisplayManager::class.java)
-            val builtInDisplays = displayManager
-                ?.getDisplays(BUILT_IN_DISPLAY_CATEGORY)
-                .orEmpty()
-            val candidateDisplays = if (builtInDisplays.isNotEmpty()) {
-                // Android 17+ returns all built-in panels, including currently inactive panels.
-                builtInDisplays.asSequence()
-            } else {
-                // Compatibility fallback for releases where the built-in category is unknown.
-                // Exclude presentation and app-owned virtual displays.
-                displayManager?.displays
-                    ?.asSequence()
-                    ?.filter { display ->
-                        display.flags and Display.FLAG_PRESENTATION == 0 &&
-                            display.flags and Display.FLAG_PRIVATE == 0
-                    }
-                    .orEmpty()
-            }
-            candidateDisplays
-                .flatMap { display ->
-                    display.supportedModes.asSequence().map { mode ->
-                        mode.physicalWidth to mode.physicalHeight
-                    }
+        // Display.Mode dimensions are reported in the panel's natural orientation. Prefer them
+        // over currentWindowMetrics so a scheduled change while a landscape game is foregrounded
+        // cannot permanently rotate and over-crop the wallpaper bitmap.
+        val displayManager = context.getSystemService(DisplayManager::class.java)
+        val builtInDisplays = displayManager
+            ?.getDisplays(BUILT_IN_DISPLAY_CATEGORY)
+            .orEmpty()
+        val candidateDisplays = if (builtInDisplays.isNotEmpty()) {
+            // Android 17+ returns all built-in panels, including currently inactive panels.
+            builtInDisplays.asSequence()
+        } else {
+            // Compatibility fallback for releases where the built-in category is unknown.
+            // Exclude presentation and app-owned virtual displays.
+            displayManager?.displays
+                ?.asSequence()
+                ?.filter { display ->
+                    display.flags and Display.FLAG_PRESENTATION == 0 &&
+                        display.flags and Display.FLAG_PRIVATE == 0
                 }
-                .forEach(::add)
+                .orEmpty()
         }
-        val largest = selectLargestDisplayDimensions(candidates)
-        return largest?.let { Size(it.first, it.second) }
-            ?: Size(metrics.bounds.width(), metrics.bounds.height())
+        val supportedModes = candidateDisplays
+            .flatMap { display ->
+                display.supportedModes.asSequence().map { mode ->
+                    mode.physicalWidth to mode.physicalHeight
+                }
+            }
+            .toList()
+        val selected = selectWallpaperDisplayDimensions(currentWindow, supportedModes)
+        return Size(selected.first, selected.second)
     }
 }
+
+/** Prefer stable natural-orientation panel modes, falling back to the current window if needed. */
+internal fun selectWallpaperDisplayDimensions(
+    currentWindow: Pair<Int, Int>,
+    supportedModes: Iterable<Pair<Int, Int>>
+): Pair<Int, Int> = selectLargestDisplayDimensions(supportedModes)
+    ?: currentWindow.takeIf { (width, height) -> width > 0 && height > 0 }
+    ?: (1 to 1)
 
 /**
  * Select the highest-resolution display dimensions.
@@ -188,58 +192,23 @@ internal fun selectLargestDisplayDimensions(
     )
 
 /**
- * Get device screen size with orientation
+ * Get the stable natural-orientation size of the largest built-in display panel.
  */
-fun getDeviceScreenSize(context: Context): Size {
-    val orientation = context.resources.configuration.orientation
-    val size = ScreenMetricsCompat.getScreenSize(context)
-    return if (orientation == Configuration.ORIENTATION_PORTRAIT) {
-        Size(minOf(size.width, size.height), maxOf(size.width, size.height))
-    } else {
-        Size(maxOf(size.width, size.height), minOf(size.width, size.height))
-    }
-}
+fun getDeviceScreenSize(context: Context): Size = ScreenMetricsCompat.getScreenSize(context)
 
 /**
  * Get the target render size for a wallpaper bitmap.
  *
- * For FIT/STRETCH/NONE on HOME (and BOTH), the launcher may request a wider canvas than the
- * physical screen to support horizontal scrolling across multiple pages. Rendering those modes
- * to the exact desired canvas prevents WallpaperManager from rescaling them into FILL.
- *
- * FILL deliberately uses one physical screen as its minimum viewport and keeps source overflow.
- * That restores Android's native static-wallpaper behavior: the launcher can traverse a wide
- * image, but cannot manufacture scroll area beyond the image's real edge.
- *
- * LOCK screen wallpapers are not parallax-scrolled, so the physical screen size is correct.
- * LIVE wallpapers are rendered by GLRenderer directly; they do not go through this path.
+ * Every static scaling mode is rendered against one physical panel. A launcher's desired
+ * wallpaper canvas may be much wider than the display; using it for FIT/NONE creates black-only
+ * viewports and using it for STRETCH distorts the image. Optional FILL scrolling retains real
+ * source overflow after decoding instead of inflating the target canvas.
  */
 fun getWallpaperRenderSize(
     context: Context,
     screenType: com.anthonyla.paperize.core.ScreenType,
     scaling: ScalingType = ScalingType.FIT
-): Size {
-    val screen = getDeviceScreenSize(context)
-    return when (screenType) {
-        com.anthonyla.paperize.core.ScreenType.HOME,
-        com.anthonyla.paperize.core.ScreenType.BOTH -> {
-            if (usesLauncherManagedScrolling(screenType, scaling)) {
-                return screen
-            }
-            val wm = WallpaperManager.getInstance(context)
-            val desiredW = wm.desiredMinimumWidth
-            val desiredH = wm.desiredMinimumHeight
-            // desiredMinimumWidth/Height return 0 when the launcher hasn't set a preference yet.
-            // Never render below the largest internal panel's resolution on a foldable.
-            if (desiredW > 0 && desiredH > 0) {
-                Size(maxOf(desiredW, screen.width), maxOf(desiredH, screen.height))
-            } else {
-                screen
-            }
-        }
-        else -> screen
-    }
-}
+): Size = getDeviceScreenSize(context)
 
 /**
  * Whether a static wallpaper should retain source overflow for launcher-managed scrolling.
@@ -248,9 +217,11 @@ fun getWallpaperRenderSize(
  */
 internal fun usesLauncherManagedScrolling(
     screenType: com.anthonyla.paperize.core.ScreenType,
-    scaling: ScalingType
+    scaling: ScalingType,
+    scrollingEnabled: Boolean
 ): Boolean =
-    (screenType == com.anthonyla.paperize.core.ScreenType.HOME ||
+    scrollingEnabled &&
+        (screenType == com.anthonyla.paperize.core.ScreenType.HOME ||
         screenType == com.anthonyla.paperize.core.ScreenType.BOTH) &&
         scaling == ScalingType.FILL
 

--- a/app/src/main/java/com/anthonyla/paperize/data/datastore/PreferencesManager.kt
+++ b/app/src/main/java/com/anthonyla/paperize/data/datastore/PreferencesManager.kt
@@ -126,6 +126,7 @@ class PreferencesManager @Inject constructor(
             homeScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE)]),
             lockScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE)]),
             liveScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE)]),
+            homeScrollingEnabled = prefs[booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED)] ?: false,
             homeEffects = WallpaperEffects(
                 enableBlur = prefs[booleanPreferencesKey(PreferenceKeys.HOME_ENABLE_BLUR)] ?: false,
                 blurPercentage = prefs[intPreferencesKey(PreferenceKeys.HOME_BLUR)] ?: 0,
@@ -189,6 +190,7 @@ class PreferencesManager @Inject constructor(
             homeScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE)]),
             lockScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE)]),
             liveScalingType = ScalingType.fromString(prefs[stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE)]),
+            homeScrollingEnabled = prefs[booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED)] ?: false,
             homeEffects = WallpaperEffects(
                 enableBlur = prefs[booleanPreferencesKey(PreferenceKeys.HOME_ENABLE_BLUR)] ?: false,
                 blurPercentage = prefs[intPreferencesKey(PreferenceKeys.HOME_BLUR)] ?: 0,
@@ -261,6 +263,7 @@ class PreferencesManager @Inject constructor(
             prefs[stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE)] = settings.homeScalingType.name
             prefs[stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE)] = settings.lockScalingType.name
             prefs[stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE)] = settings.liveScalingType.name
+            prefs[booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED)] = settings.homeScrollingEnabled
 
             // Home effects
             prefs[booleanPreferencesKey(PreferenceKeys.HOME_ENABLE_BLUR)] = settings.homeEffects.enableBlur
@@ -524,6 +527,7 @@ class PreferencesManager @Inject constructor(
             prefs.remove(stringPreferencesKey(PreferenceKeys.HOME_SCALING_TYPE))
             prefs.remove(stringPreferencesKey(PreferenceKeys.LOCK_SCALING_TYPE))
             prefs.remove(stringPreferencesKey(PreferenceKeys.LIVE_SCALING_TYPE))
+            prefs.remove(booleanPreferencesKey(PreferenceKeys.HOME_SCROLLING_ENABLED))
 
             // Clear adaptive brightness
             prefs.remove(booleanPreferencesKey(PreferenceKeys.ADAPTIVE_BRIGHTNESS))

--- a/app/src/main/java/com/anthonyla/paperize/domain/model/ScheduleSettings.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/model/ScheduleSettings.kt
@@ -19,6 +19,7 @@ data class ScheduleSettings(
     val liveIntervalMinutes: Int = Constants.DEFAULT_INTERVAL_MINUTES,
     val homeScalingType: ScalingType = ScalingType.FILL,
     val lockScalingType: ScalingType = ScalingType.FILL,
+    val homeScrollingEnabled: Boolean = false,
     val homeEffects: WallpaperEffects = WallpaperEffects.none(),
     val lockEffects: WallpaperEffects = WallpaperEffects.none(),
     val liveAlbumId: String? = null,
@@ -67,6 +68,7 @@ data class ScheduleSettings(
     fun hasDisplayChanges(other: ScheduleSettings): Boolean {
         return homeScalingType != other.homeScalingType ||
                lockScalingType != other.lockScalingType ||
+               homeScrollingEnabled != other.homeScrollingEnabled ||
                homeEffects != other.homeEffects ||
                lockEffects != other.lockEffects ||
                liveEffects != other.liveEffects ||

--- a/app/src/main/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCase.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCase.kt
@@ -63,7 +63,11 @@ class ChangeWallpaperUseCase @Inject constructor(
                 ScreenType.HOME, ScreenType.BOTH -> settings.homeScalingType
                 ScreenType.LOCK -> settings.lockScalingType
             }
-            val preserveSourceOverflow = usesLauncherManagedScrolling(screenType, scaling)
+            val preserveSourceOverflow = usesLauncherManagedScrolling(
+                screenType,
+                scaling,
+                settings.homeScrollingEnabled
+            )
             val screenSize = getWallpaperRenderSize(context, screenType, scaling)
 
             var finalBitmap: Bitmap? = null

--- a/app/src/main/java/com/anthonyla/paperize/domain/usecase/ReapplyEffectsUseCase.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/usecase/ReapplyEffectsUseCase.kt
@@ -54,7 +54,11 @@ class ReapplyEffectsUseCase @Inject constructor(
                 ScreenType.HOME, ScreenType.BOTH -> settings.homeScalingType
                 ScreenType.LOCK -> settings.lockScalingType
             }
-            val preserveSourceOverflow = usesLauncherManagedScrolling(screenType, scaling)
+            val preserveSourceOverflow = usesLauncherManagedScrolling(
+                screenType,
+                scaling,
+                settings.homeScrollingEnabled
+            )
             val screenSize = getWallpaperRenderSize(context, screenType, scaling)
 
             val uri = current.uri.toUri()

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeViewModel.kt
@@ -300,9 +300,6 @@ class HomeViewModel @Inject constructor(
             } else if (updated.enableChanger) {
                 // Album selected and changer is enabled - schedule alarms
                 scheduleAlarms(updated)
-            } else {
-                // Album selected but changer is not enabled - enable it
-                toggleWallpaperChanger(true)
             }
         }
     }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/WallpaperScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/WallpaperScreen.kt
@@ -117,37 +117,6 @@ fun WallpaperScreen(
         }
     }
 
-    // Auto-toggle wallpaper changer based on album selection state
-    // Use IDs as source of truth - if ID is set, we trust it's valid
-    // The ID will only be cleared when user explicitly deselects, not due to loading race conditions
-    LaunchedEffect(scheduleSettings.homeAlbumId, scheduleSettings.lockAlbumId, scheduleSettings.liveAlbumId, homeEnabled, lockEnabled, wallpaperMode) {
-        val allRequiredAlbumsSet = if (wallpaperMode == WallpaperMode.STATIC) {
-            when {
-                homeEnabled && lockEnabled -> {
-                    // Both are enabled, require both album IDs to be set
-                    scheduleSettings.homeAlbumId != null && scheduleSettings.lockAlbumId != null
-                }
-                homeEnabled -> {
-                    // Only home is enabled, require home album ID to be set
-                    scheduleSettings.homeAlbumId != null
-                }
-                lockEnabled -> {
-                    // Only lock is enabled, require lock album ID to be set
-                    scheduleSettings.lockAlbumId != null
-                }
-                else -> false // Neither enabled, should be disabled
-            }
-        } else {
-            // Live mode: require live album ID to be set
-            scheduleSettings.liveAlbumId != null
-        }
-
-        // Only update if current state doesn't match desired state (prevents redundant calls)
-        if (allRequiredAlbumsSet != scheduleSettings.enableChanger) {
-            onToggleChanger(allRequiredAlbumsSet)
-        }
-    }
-
     val scalingOptions = listOf(
         stringResource(R.string.fill),
         stringResource(R.string.fit),
@@ -505,6 +474,27 @@ fun WallpaperScreen(
             scheduleSettings.liveAlbumId != null
         }
 
+        val allRequiredAlbumsSelected = if (wallpaperMode == WallpaperMode.STATIC) {
+            when {
+                homeEnabled && lockEnabled ->
+                    scheduleSettings.homeAlbumId != null && scheduleSettings.lockAlbumId != null
+                homeEnabled -> scheduleSettings.homeAlbumId != null
+                lockEnabled -> scheduleSettings.lockAlbumId != null
+                else -> false
+            }
+        } else {
+            scheduleSettings.liveAlbumId != null
+        }
+
+        if (allRequiredAlbumsSelected) {
+            SettingSwitchItem(
+                title = stringResource(R.string.wallpaper_changer),
+                description = stringResource(R.string.wallpaper_changer_description),
+                checked = scheduleSettings.enableChanger,
+                onCheckedChange = onToggleChanger
+            )
+        }
+
         // Time interval pickers (only show if album is selected)
         if (hasAlbumSelected) {
             if (wallpaperMode == WallpaperMode.STATIC) {
@@ -564,6 +554,19 @@ fun WallpaperScreen(
         HorizontalDivider(modifier = Modifier.padding(vertical = AppSpacing.small))
 
         // Current Wallpaper Preview (Static Mode Only)
+        if (wallpaperMode == WallpaperMode.STATIC) {
+            SettingSwitchItem(
+                title = stringResource(R.string.horizontal_wallpaper_scrolling),
+                description = stringResource(R.string.horizontal_wallpaper_scrolling_description),
+                checked = scheduleSettings.homeScrollingEnabled,
+                onCheckedChange = { enabled ->
+                    updateSettingsImmediate(
+                        scheduleSettings.copy(homeScrollingEnabled = enabled)
+                    )
+                }
+            )
+        }
+
         if (wallpaperMode == WallpaperMode.STATIC) {
             CurrentWallpaperPreview(
                 homeWallpaperUri = homeWallpaperUri,
@@ -643,7 +646,7 @@ fun WallpaperScreen(
             }
         }
 
-        if (scheduleSettings.enableChanger) {
+        if (hasAlbumSelected) {
             Button(
                 onClick = onChangeWallpaperNow,
                 modifier = Modifier

--- a/app/src/main/java/com/anthonyla/paperize/service/wallpaper/WallpaperChangeService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/wallpaper/WallpaperChangeService.kt
@@ -166,7 +166,8 @@ class WallpaperChangeService : Service() {
                 val prepared = result.data
                 val samePresentation =
                     settings.homeEffects == settings.lockEffects &&
-                        settings.homeScalingType == settings.lockScalingType
+                        settings.homeScalingType == settings.lockScalingType &&
+                        !settings.homeScrollingEnabled
 
                 if (samePresentation) {
                     applyPrepared(

--- a/app/src/main/java/com/anthonyla/paperize/service/worker/WallpaperChangeWorker.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/worker/WallpaperChangeWorker.kt
@@ -112,7 +112,8 @@ class WallpaperChangeWorker @AssistedInject constructor(
                 val prepared = result.data
                 val samePresentation =
                     settings.homeEffects == settings.lockEffects &&
-                        settings.homeScalingType == settings.lockScalingType
+                        settings.homeScalingType == settings.lockScalingType &&
+                        !settings.homeScrollingEnabled
 
                 if (samePresentation) {
                     applyPrepared(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,10 @@
 
   <!-- UI Labels and Status -->
   <string name="enabled">Enabled</string>
+  <string name="wallpaper_changer">Wallpaper changing</string>
+  <string name="wallpaper_changer_description">Pause or resume scheduled changes without clearing your albums.</string>
+  <string name="horizontal_wallpaper_scrolling">Horizontal scrolling</string>
+  <string name="horizontal_wallpaper_scrolling_description">Allow wide Fill wallpapers to move between home-screen pages. Lock-screen wallpapers remain centered.</string>
   <string name="disabled">Disabled</string>
   <string name="lock_album_label">Lock Album</string>
   <string name="home_album_label">Home Album</string>

--- a/app/src/test/java/com/anthonyla/paperize/core/util/ScreenMetricsCompatTest.kt
+++ b/app/src/test/java/com/anthonyla/paperize/core/util/ScreenMetricsCompatTest.kt
@@ -48,16 +48,37 @@ class ScreenMetricsCompatTest {
     }
 
     @Test
-    fun `home fill preserves overflow for launcher scrolling`() {
-        assertTrue(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.FILL))
-        assertTrue(usesLauncherManagedScrolling(ScreenType.BOTH, ScalingType.FILL))
+    fun `natural display mode wins while current window is landscape`() {
+        val result = selectWallpaperDisplayDimensions(
+            currentWindow = 2400 to 1080,
+            supportedModes = listOf(1080 to 2400)
+        )
+
+        assertEquals(1080 to 2400, result)
+    }
+
+    @Test
+    fun `current window is used when display modes are unavailable`() {
+        val result = selectWallpaperDisplayDimensions(
+            currentWindow = 1920 to 1080,
+            supportedModes = emptyList()
+        )
+
+        assertEquals(1920 to 1080, result)
+    }
+
+    @Test
+    fun `home fill preserves overflow only when scrolling is enabled`() {
+        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.FILL, false))
+        assertTrue(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.FILL, true))
+        assertTrue(usesLauncherManagedScrolling(ScreenType.BOTH, ScalingType.FILL, true))
     }
 
     @Test
     fun `non-fill and lock rendering use exact canvas`() {
-        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.FIT))
-        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.STRETCH))
-        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.NONE))
-        assertFalse(usesLauncherManagedScrolling(ScreenType.LOCK, ScalingType.FILL))
+        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.FIT, true))
+        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.STRETCH, true))
+        assertFalse(usesLauncherManagedScrolling(ScreenType.HOME, ScalingType.NONE, true))
+        assertFalse(usesLauncherManagedScrolling(ScreenType.LOCK, ScalingType.FILL, true))
     }
 }

--- a/app/src/test/java/com/anthonyla/paperize/domain/model/ScheduleSettingsTest.kt
+++ b/app/src/test/java/com/anthonyla/paperize/domain/model/ScheduleSettingsTest.kt
@@ -161,6 +161,14 @@ class ScheduleSettingsTest {
     }
 
     @Test
+    fun `hasDisplayChanges returns true when home scrolling changes`() {
+        val settings1 = ScheduleSettings(homeScrollingEnabled = false)
+        val settings2 = ScheduleSettings(homeScrollingEnabled = true)
+
+        assertTrue(settings1.hasDisplayChanges(settings2))
+    }
+
+    @Test
     fun `hasDisplayChanges returns true when homeEffects change`() {
         val settings1 = ScheduleSettings(homeEffects = WallpaperEffects(enableBlur = false))
         val settings2 = ScheduleSettings(homeEffects = WallpaperEffects(enableBlur = true))
@@ -227,6 +235,7 @@ class ScheduleSettingsTest {
         assertFalse(settings.shuffleEnabled)
         assertFalse(settings.homeEnabled)
         assertFalse(settings.lockEnabled)
+        assertFalse(settings.homeScrollingEnabled)
         assertNull(settings.homeAlbumId)
         assertNull(settings.lockAlbumId)
         assertEquals(Constants.DEFAULT_INTERVAL_MINUTES, settings.homeIntervalMinutes)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,6 @@ androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version = "2.11.2" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
-coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 google-material = { module = "com.google.android.material:material", version.ref = "material" }


### PR DESCRIPTION
## Summary

This fixes the post-v4.0.2 regressions reported in the static wallpaper renderer and makes the wallpaper changer independently pausable without losing album selections.

### Root causes

- Scheduled work could read the foreground app's landscape configuration and rotate the target canvas even though the physical display remained portrait.
- Static scaling modes reused the launcher's requested wide wallpaper surface, distorting FIT, STRETCH, and NONE and forcing FILL to scroll.
- Album selection implicitly enabled scheduling, so users could not pause changes while keeping their configuration.

### Changes

- Resolve a stable natural display size from the built-in display mode.
- Render all static modes against one physical display panel.
- Center FILL by default and add an explicit persisted horizontal-scrolling opt-in.
- When scrolling is enabled for both targets, write home and lock separately so the lock screen stays centered.
- Add a persistent **Wallpaper changing** switch; manual changes remain available while paused.
- Remove the unused network loader and transitive ACCESS_NETWORK_STATE permission.
- Update Hilt/coroutines-test and add regression coverage.

### Verification

- 271 unit tests passed.
- Android lint passed.
- Android-test APK compiled.
- 9/9 connected tests passed on Android 17; 8/9 passed on Android 16 with the Android-17-only case skipped as expected.
- Device audit verified FIT, FILL, STRETCH, and NONE; portrait and landscape app states; centered and scrolling home output; centered lock output; pause/resume persistence and WorkManager cancellation/recreation.
- Live wallpaper audit verified service activation, EGL/shader initialization, large-texture tiling, image reload/crossfade, double-tap reload, screen-off reload, and blur/darken/vignette/grayscale/parallax updates.
- Final merged manifests contain neither INTERNET nor ACCESS_NETWORK_STATE.

Fixes #538
Fixes #577
Fixes #578
Fixes #580
Fixes #581