### PR TITLE
Release Paperize v4.1.0

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository source code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -70,10 +70,10 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Checkout repository source code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -154,7 +154,7 @@ jobs:
       - name: Create Draft Release
         # Publishes a new release to GitHub. `draft: true` ensures the release is not made
         # public until it has been manually reviewed and published.
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           files: ./apk-artifact/paperize-v*.apk
           draft: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,33 +18,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository source code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: actions
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
 
   analyze-java-kotlin:
     name: Analyze Java and Kotlin
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository source code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           java-version: "17"
           distribution: temurin
           cache: gradle
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: java-kotlin
           build-mode: manual
@@ -56,4 +56,4 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v4.1.0
+
+- Added a Set wallpaper action to image previews, with separate home, lock, and
+  combined home-and-lock targets that preserve each screen's scaling and effects.
+- Reset the affected automatic countdown after a successful manual change from
+  Paperize, its launcher shortcut, or its Quick Settings tile.
+- Added live-wallpaper intervals as short as one minute while the wallpaper is
+  visible, with lifecycle-aware pausing and timer resets after manual changes.
+- Replaced the undersized status-bar asset with a dedicated notification icon.
+- Updated Paperize for the Android 17 SDK and refreshed Kotlin, Gradle, Compose,
+  AndroidX, Material, Coil, Zoomable, and GitHub Actions dependencies.
+- Expanded emulator coverage for Android wallpaper colors, every static and live
+  visual effect, OpenGL shaders, scheduling policy, and foldable display sizing.
+
+**Full Changelog**: https://github.com/Anthonyy232/Paperize/compare/v4.0.3...v4.1.0
+
 ## v4.0.3
 
 - Kept scheduled static changes in the device's natural orientation, even when a

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ ksp {
 
 android {
     namespace = "com.anthonyla.paperize"
-    compileSdk = 36
+    compileSdk = 37
 
     signingConfigs {
         create("release") {
@@ -32,8 +32,8 @@ android {
         applicationId = "com.anthonyla.paperize"
         minSdk = 31
         targetSdk = 36
-        versionCode = 54
-        versionName = "4.0.3"
+        versionCode = 55
+        versionName = "4.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/androidTest/java/com/anthonyla/paperize/core/util/WallpaperUtilInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/anthonyla/paperize/core/util/WallpaperUtilInstrumentedTest.kt
@@ -1,11 +1,13 @@
 package com.anthonyla.paperize.core.util
 
+import android.app.WallpaperManager
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.hardware.display.DisplayManager
 import android.net.Uri
 import android.os.Build
-import android.content.res.Configuration
+import android.os.SystemClock
 import androidx.exifinterface.media.ExifInterface
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -223,6 +225,55 @@ class WallpaperUtilInstrumentedTest {
         assertTrue("Expected blurred boundary, got $boundary", boundary in 2..253)
         if (result !== source) source.recycle()
         result.recycle()
+    }
+
+    @Test
+    fun staticWallpaperChangesRefreshAospWallpaperColors() {
+        assumeTrue(
+            "Wallpaper color extraction test is destructive and must run only on an emulator",
+            Build.FINGERPRINT.contains("/emu") ||
+                Build.FINGERPRINT.contains("generic") ||
+                Build.MODEL.contains("Emulator", ignoreCase = true) ||
+                Build.MODEL.contains("sdk", ignoreCase = true)
+        )
+        val wallpaperManager = WallpaperManager.getInstance(context)
+        val red = mutableBitmap(256, 256, Color.rgb(230, 20, 20))
+        val blue = mutableBitmap(256, 256, Color.rgb(20, 20, 230))
+
+        try {
+            wallpaperManager.setBitmapChecked(red, WallpaperManager.FLAG_SYSTEM)
+            val redPrimary = awaitPrimaryWallpaperColor(wallpaperManager) { color ->
+                Color.red(color) > Color.blue(color) * 2
+            }
+
+            wallpaperManager.setBitmapChecked(blue, WallpaperManager.FLAG_SYSTEM)
+            val bluePrimary = awaitPrimaryWallpaperColor(wallpaperManager) { color ->
+                Color.blue(color) > Color.red(color) * 2
+            }
+
+            assertTrue(Color.red(redPrimary) > Color.blue(redPrimary))
+            assertTrue(Color.blue(bluePrimary) > Color.red(bluePrimary))
+        } finally {
+            red.recycle()
+            blue.recycle()
+        }
+    }
+
+    private fun awaitPrimaryWallpaperColor(
+        wallpaperManager: WallpaperManager,
+        predicate: (Int) -> Boolean
+    ): Int {
+        val deadline = SystemClock.uptimeMillis() + 10_000L
+        var lastColor: Int? = null
+        while (SystemClock.uptimeMillis() < deadline) {
+            lastColor = wallpaperManager
+                .getWallpaperColors(WallpaperManager.FLAG_SYSTEM)
+                ?.primaryColor
+                ?.toArgb()
+            if (lastColor != null && predicate(lastColor)) return lastColor
+            SystemClock.sleep(100L)
+        }
+        throw AssertionError("Wallpaper colors did not refresh; last primary color was $lastColor")
     }
 
     private fun mutableBitmap(width: Int, height: Int, color: Int): Bitmap =

--- a/app/src/androidTest/java/com/anthonyla/paperize/service/livewallpaper/renderer/LiveWallpaperShaderInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/anthonyla/paperize/service/livewallpaper/renderer/LiveWallpaperShaderInstrumentedTest.kt
@@ -1,0 +1,284 @@
+package com.anthonyla.paperize.service.livewallpaper.renderer
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import android.opengl.EGLSurface
+import android.opengl.GLES20
+import android.opengl.GLUtils
+import android.opengl.Matrix
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.anthonyla.paperize.service.livewallpaper.gl.GLUtil
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LiveWallpaperShaderInstrumentedTest {
+    private lateinit var display: EGLDisplay
+    private lateinit var context: EGLContext
+    private lateinit var surface: EGLSurface
+
+    @Before
+    fun createGlContext() {
+        display = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
+        assertTrue(display != EGL14.EGL_NO_DISPLAY)
+        assertTrue(EGL14.eglInitialize(display, IntArray(2), 0, IntArray(2), 0))
+
+        val configs = arrayOfNulls<EGLConfig>(1)
+        val configCount = IntArray(1)
+        assertTrue(
+            EGL14.eglChooseConfig(
+                display,
+                intArrayOf(
+                    EGL14.EGL_SURFACE_TYPE, EGL14.EGL_PBUFFER_BIT,
+                    EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+                    EGL14.EGL_RED_SIZE, 8,
+                    EGL14.EGL_GREEN_SIZE, 8,
+                    EGL14.EGL_BLUE_SIZE, 8,
+                    EGL14.EGL_ALPHA_SIZE, 8,
+                    EGL14.EGL_NONE
+                ),
+                0,
+                configs,
+                0,
+                configs.size,
+                configCount,
+                0
+            )
+        )
+        val config = requireNotNull(configs.first())
+        context = EGL14.eglCreateContext(
+            display,
+            config,
+            EGL14.EGL_NO_CONTEXT,
+            intArrayOf(EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, EGL14.EGL_NONE),
+            0
+        )
+        surface = EGL14.eglCreatePbufferSurface(
+            display,
+            config,
+            intArrayOf(EGL14.EGL_WIDTH, SIZE, EGL14.EGL_HEIGHT, SIZE, EGL14.EGL_NONE),
+            0
+        )
+        assertTrue(EGL14.eglMakeCurrent(display, surface, surface, context))
+        GLES20.glViewport(0, 0, SIZE, SIZE)
+        GLES20.glDisable(GLES20.GL_BLEND)
+    }
+
+    @After
+    fun destroyGlContext() {
+        EGL14.eglMakeCurrent(
+            display,
+            EGL14.EGL_NO_SURFACE,
+            EGL14.EGL_NO_SURFACE,
+            EGL14.EGL_NO_CONTEXT
+        )
+        EGL14.eglDestroySurface(display, surface)
+        EGL14.eglDestroyContext(display, context)
+        EGL14.eglTerminate(display)
+    }
+
+    @Test
+    fun everyLiveWallpaperShaderCompilesAndLinksOnDevice() {
+        listOf(
+            GLShaders.SIMPLE_FRAGMENT_SHADER,
+            GLShaders.BLUR_HORIZONTAL_FRAGMENT_SHADER,
+            GLShaders.BLUR_VERTICAL_FRAGMENT_SHADER,
+            GLShaders.EFFECTS_FRAGMENT_SHADER
+        ).forEach { fragmentShader ->
+            val program = GLUtil.createProgram(GLShaders.VERTEX_SHADER, fragmentShader)
+            assertTrue(program != 0)
+            GLES20.glDeleteProgram(program)
+        }
+    }
+
+    @Test
+    fun liveColorEffectsChangeRenderedPixels() {
+        val sourceColor = Color.rgb(200, 100, 40)
+        val texture = createTexture(solidBitmap(sourceColor))
+        val program = GLUtil.createProgram(GLShaders.VERTEX_SHADER, GLShaders.EFFECTS_FRAGMENT_SHADER)
+
+        try {
+            drawEffects(program, texture)
+            val baseline = readPixel(SIZE / 2, SIZE / 2)
+            assertTrue(Color.red(baseline) in 195..205)
+            assertTrue(Color.green(baseline) in 95..105)
+
+            drawEffects(program, texture, darken = 1f)
+            assertTrue(Color.red(readPixel(SIZE / 2, SIZE / 2)) <= 2)
+
+            drawEffects(program, texture, grayscale = 1f)
+            val gray = readPixel(SIZE / 2, SIZE / 2)
+            assertTrue(kotlin.math.abs(Color.red(gray) - Color.green(gray)) <= 2)
+            assertTrue(kotlin.math.abs(Color.green(gray) - Color.blue(gray)) <= 2)
+
+            drawEffects(program, texture, adaptiveBrightness = 0.5f)
+            val dimmed = readPixel(SIZE / 2, SIZE / 2)
+            assertTrue(Color.red(dimmed) in 95..105)
+
+            drawEffects(program, texture, vignette = 1f)
+            val center = Color.red(readPixel(SIZE / 2, SIZE / 2))
+            val corner = Color.red(readPixel(1, 1))
+            assertTrue("Expected vignette corner $corner below center $center", corner < center)
+        } finally {
+            GLES20.glDeleteProgram(program)
+            GLES20.glDeleteTextures(1, intArrayOf(texture), 0)
+        }
+    }
+
+    @Test
+    fun liveBlurShadersSoftenHorizontalAndVerticalBoundaries() {
+        val horizontal = boundaryBitmap(horizontalBoundary = true)
+        val vertical = boundaryBitmap(horizontalBoundary = false)
+        val horizontalTexture = createTexture(horizontal)
+        val verticalTexture = createTexture(vertical)
+
+        val horizontalProgram = GLUtil.createProgram(
+            GLShaders.VERTEX_SHADER,
+            GLShaders.BLUR_HORIZONTAL_FRAGMENT_SHADER
+        )
+        val verticalProgram = GLUtil.createProgram(
+            GLShaders.VERTEX_SHADER,
+            GLShaders.BLUR_VERTICAL_FRAGMENT_SHADER
+        )
+        try {
+            drawBlur(horizontalProgram, horizontalTexture)
+            assertTrue(Color.red(readPixel(SIZE / 2, SIZE / 2)) in 10..245)
+
+            drawBlur(verticalProgram, verticalTexture)
+            assertTrue(Color.red(readPixel(SIZE / 2, SIZE / 2)) in 10..245)
+        } finally {
+            GLES20.glDeleteProgram(horizontalProgram)
+            GLES20.glDeleteProgram(verticalProgram)
+            GLES20.glDeleteTextures(2, intArrayOf(horizontalTexture, verticalTexture), 0)
+        }
+    }
+
+    private fun drawEffects(
+        program: Int,
+        texture: Int,
+        darken: Float = 0f,
+        vignette: Float = 0f,
+        grayscale: Float = 0f,
+        adaptiveBrightness: Float = 1f
+    ) {
+        prepareDraw(program, texture)
+        GLES20.glUniform1f(GLES20.glGetUniformLocation(program, "u_alpha"), 1f)
+        GLES20.glUniform1f(GLES20.glGetUniformLocation(program, "u_darkenFactor"), darken)
+        GLES20.glUniform1f(GLES20.glGetUniformLocation(program, "u_vignetteFactor"), vignette)
+        GLES20.glUniform1f(GLES20.glGetUniformLocation(program, "u_grayscaleFactor"), grayscale)
+        GLES20.glUniform1f(
+            GLES20.glGetUniformLocation(program, "u_adaptiveBrightnessFactor"),
+            adaptiveBrightness
+        )
+        finishDraw(program)
+    }
+
+    private fun drawBlur(program: Int, texture: Int) {
+        prepareDraw(program, texture)
+        GLES20.glUniform2f(GLES20.glGetUniformLocation(program, "u_resolution"), SIZE.toFloat(), SIZE.toFloat())
+        GLES20.glUniform1f(GLES20.glGetUniformLocation(program, "u_blurRadius"), 4f)
+        finishDraw(program)
+    }
+
+    private fun prepareDraw(program: Int, texture: Int) {
+        GLES20.glClearColor(0f, 0f, 0f, 1f)
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+        GLES20.glUseProgram(program)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture)
+        GLES20.glUniform1i(GLES20.glGetUniformLocation(program, "u_texture"), 0)
+
+        val identity = FloatArray(16).also { Matrix.setIdentityM(it, 0) }
+        GLES20.glUniformMatrix4fv(
+            GLES20.glGetUniformLocation(program, "u_mvpMatrix"),
+            1,
+            false,
+            identity,
+            0
+        )
+
+        val position = GLES20.glGetAttribLocation(program, "a_position")
+        val textureCoordinate = GLES20.glGetAttribLocation(program, "a_texCoord")
+        GLES20.glEnableVertexAttribArray(position)
+        GLES20.glEnableVertexAttribArray(textureCoordinate)
+        GLES20.glVertexAttribPointer(position, 2, GLES20.GL_FLOAT, false, 0, floatBuffer(VERTICES))
+        GLES20.glVertexAttribPointer(
+            textureCoordinate,
+            2,
+            GLES20.GL_FLOAT,
+            false,
+            0,
+            floatBuffer(TEXTURE_COORDINATES)
+        )
+    }
+
+    private fun finishDraw(program: Int) {
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+        GLES20.glFinish()
+        GLES20.glDisableVertexAttribArray(GLES20.glGetAttribLocation(program, "a_position"))
+        GLES20.glDisableVertexAttribArray(GLES20.glGetAttribLocation(program, "a_texCoord"))
+        GLUtil.checkGLError("live wallpaper shader draw")
+    }
+
+    private fun createTexture(bitmap: Bitmap): Int {
+        val texture = IntArray(1)
+        GLES20.glGenTextures(1, texture, 0)
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture[0])
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+        GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0)
+        if (!bitmap.isRecycled) bitmap.recycle()
+        return texture[0]
+    }
+
+    private fun readPixel(x: Int, y: Int): Int {
+        val buffer = ByteBuffer.allocateDirect(4)
+        GLES20.glReadPixels(x, y, 1, 1, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, buffer)
+        return Color.argb(
+            buffer.get(3).toInt() and 0xff,
+            buffer.get(0).toInt() and 0xff,
+            buffer.get(1).toInt() and 0xff,
+            buffer.get(2).toInt() and 0xff
+        )
+    }
+
+    private fun solidBitmap(color: Int): Bitmap =
+        Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888).apply { eraseColor(color) }
+
+    private fun boundaryBitmap(horizontalBoundary: Boolean): Bitmap =
+        Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888).apply {
+            for (y in 0 until SIZE) {
+                for (x in 0 until SIZE) {
+                    val white = if (horizontalBoundary) x >= SIZE / 2 else y >= SIZE / 2
+                    setPixel(x, y, if (white) Color.WHITE else Color.BLACK)
+                }
+            }
+        }
+
+    private fun floatBuffer(values: FloatArray): FloatBuffer =
+        ByteBuffer.allocateDirect(values.size * Float.SIZE_BYTES)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer()
+            .apply {
+                put(values)
+                position(0)
+            }
+
+    private companion object {
+        const val SIZE = 64
+        val VERTICES = floatArrayOf(-1f, -1f, 1f, -1f, -1f, 1f, 1f, 1f)
+        val TEXTURE_COORDINATES = floatArrayOf(0f, 0f, 1f, 0f, 0f, 1f, 1f, 1f)
+    }
+}

--- a/app/src/main/java/com/anthonyla/paperize/core/constants/Constants.kt
+++ b/app/src/main/java/com/anthonyla/paperize/core/constants/Constants.kt
@@ -17,6 +17,8 @@ object Constants {
 
     // Services
     const val ACTION_CHANGE_WALLPAPER = "com.anthonyla.paperize.ACTION_CHANGE_WALLPAPER"
+    const val ACTION_APPLY_SPECIFIC_WALLPAPER =
+        "com.anthonyla.paperize.ACTION_APPLY_SPECIFIC_WALLPAPER"
     const val ACTION_REAPPLY_EFFECTS = "com.anthonyla.paperize.ACTION_REAPPLY_EFFECTS"
     const val ACTION_RELOAD_WALLPAPER = "com.anthonyla.paperize.ACTION_RELOAD_WALLPAPER"
 
@@ -35,6 +37,7 @@ object Constants {
 
     // Intents
     const val EXTRA_SCREEN_TYPE = "screen_type"
+    const val EXTRA_WALLPAPER_ID = "wallpaper_id"
 
     // Wallpaper
     const val DEFAULT_BLUR_PERCENTAGE = 0
@@ -49,6 +52,7 @@ object Constants {
     const val FLOW_SUBSCRIPTION_TIMEOUT_MS = 5000L
 
     // Scheduling
+    const val MIN_LIVE_INTERVAL_MINUTES = 1
     const val MIN_INTERVAL_MINUTES = 15
     const val MAX_INTERVAL_MINUTES = 43200  // 30 days in minutes
     const val DEFAULT_INTERVAL_MINUTES = 60

--- a/app/src/main/java/com/anthonyla/paperize/domain/model/ScheduleSettings.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/model/ScheduleSettings.kt
@@ -33,7 +33,7 @@ data class ScheduleSettings(
     fun validate(): ScheduleSettings = copy(
         homeIntervalMinutes = homeIntervalMinutes.coerceAtLeast(Constants.MIN_INTERVAL_MINUTES),
         lockIntervalMinutes = lockIntervalMinutes.coerceAtLeast(Constants.MIN_INTERVAL_MINUTES),
-        liveIntervalMinutes = liveIntervalMinutes.coerceAtLeast(Constants.MIN_INTERVAL_MINUTES),
+        liveIntervalMinutes = liveIntervalMinutes.coerceAtLeast(Constants.MIN_LIVE_INTERVAL_MINUTES),
         homeEffects = homeEffects.validate(),
         lockEffects = lockEffects.validate(),
         liveEffects = liveEffects.validate()
@@ -80,3 +80,10 @@ data class ScheduleSettings(
         fun default() = ScheduleSettings()
     }
 }
+
+/**
+ * WorkManager cannot run periodic jobs more often than every 15 minutes. Short live-wallpaper
+ * intervals are therefore driven by the visible wallpaper engine and stop when it is hidden.
+ */
+fun usesVisibleLiveTimer(intervalMinutes: Int): Boolean =
+    intervalMinutes in Constants.MIN_LIVE_INTERVAL_MINUTES until Constants.MIN_INTERVAL_MINUTES

--- a/app/src/main/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCase.kt
+++ b/app/src/main/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCase.kt
@@ -181,12 +181,25 @@ class ChangeWallpaperUseCase @Inject constructor(
     suspend fun complete(
         prepared: PreparedWallpaper,
         screenType: ScreenType = prepared.screenType
+    ) = completeSpecific(
+        albumId = prepared.albumId,
+        screenType = screenType,
+        wallpaperId = prepared.wallpaperId,
+        shuffle = prepared.shuffle
+    )
+
+    /** Record a user-selected wallpaper and remove that exact item from the next-change queue. */
+    suspend fun completeSpecific(
+        albumId: String,
+        screenType: ScreenType,
+        wallpaperId: String,
+        shuffle: Boolean
     ) {
         try {
             wallpaperRepository.setCurrentWallpaper(
-                prepared.albumId,
+                albumId,
                 screenType,
-                prepared.wallpaperId
+                wallpaperId
             )
         } catch (e: Exception) {
             Log.e(TAG, "Applied wallpaper could not be recorded as current", e)
@@ -194,20 +207,20 @@ class ChangeWallpaperUseCase @Inject constructor(
         }
 
         try {
-            if (wallpaperRepository.getNextWallpaperInQueue(prepared.albumId, screenType) == null) {
+            if (wallpaperRepository.getNextWallpaperInQueue(albumId, screenType) == null) {
                 wallpaperRepository.buildWallpaperQueue(
-                    prepared.albumId,
+                    albumId,
                     screenType,
-                    prepared.shuffle
+                    shuffle
                 )
             }
             // Build first when this is the first synchronized use of a screen queue, then remove
             // the exact applied item. This prevents the just-applied wallpaper from being
             // reintroduced at the head of a freshly built queue.
             wallpaperRepository.removeWallpaperFromQueue(
-                prepared.albumId,
+                albumId,
                 screenType,
-                prepared.wallpaperId
+                wallpaperId
             )
         } catch (e: Exception) {
             Log.w(TAG, "Queue sync failed; it will rebuild on the next change", e)

--- a/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/NavigationGraph.kt
@@ -142,8 +142,10 @@ fun NavigationGraph(
                 onNavigateToFolder = { folderId ->
                     navController.navigate(FolderRoute(folderId))
                 },
-                onNavigateToWallpaperView = { wallpaperUri, wallpaperName ->
-                    navController.navigate(WallpaperViewRoute(wallpaperUri, wallpaperName))
+                onNavigateToWallpaperView = { wallpaperId, wallpaperUri, wallpaperName ->
+                    navController.navigate(
+                        WallpaperViewRoute(wallpaperId, wallpaperUri, wallpaperName)
+                    )
                 }
             )
         }
@@ -172,8 +174,10 @@ fun NavigationGraph(
             backStackEntry.toRoute<FolderRoute>()
             FolderViewScreen(
                 onBackClick = { navController.popBackStack() },
-                onNavigateToWallpaperView = { wallpaperUri, wallpaperName ->
-                    navController.navigate(WallpaperViewRoute(wallpaperUri, wallpaperName))
+                onNavigateToWallpaperView = { wallpaperId, wallpaperUri, wallpaperName ->
+                    navController.navigate(
+                        WallpaperViewRoute(wallpaperId, wallpaperUri, wallpaperName)
+                    )
                 }
             )
         }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/Routes.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/common/navigation/Routes.kt
@@ -25,7 +25,11 @@ data class AlbumRoute(val albumId: String)
 data class FolderRoute(val folderId: String)
 
 @Serializable
-data class WallpaperViewRoute(val wallpaperUri: String, val wallpaperName: String)
+data class WallpaperViewRoute(
+    val wallpaperId: String,
+    val wallpaperUri: String,
+    val wallpaperName: String
+)
 
 @Serializable
 data class SortRoute(val albumId: String)

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/AlbumViewScreen.kt
@@ -48,7 +48,7 @@ import com.anthonyla.paperize.presentation.theme.AppSpacing
 fun AlbumViewScreen(
     onBackClick: () -> Unit,
     onNavigateToFolder: (String) -> Unit,
-    onNavigateToWallpaperView: (String, String) -> Unit,
+    onNavigateToWallpaperView: (String, String, String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: AlbumViewViewModel = hiltViewModel()
 ) {
@@ -221,7 +221,11 @@ fun AlbumViewScreen(
                         if (isSelectionMode) {
                             viewModel.toggleWallpaperSelection(wallpaper.id)
                         } else {
-                            onNavigateToWallpaperView(wallpaper.uri, wallpaper.fileName)
+                            onNavigateToWallpaperView(
+                                wallpaper.id,
+                                wallpaper.uri,
+                                wallpaper.fileName
+                            )
                         }
                     },
                     onLongClick = {

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/components/SortBottomSheet.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/album_view/components/SortBottomSheet.kt
@@ -13,8 +13,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -41,7 +42,10 @@ fun SortBottomSheet(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
+    )
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -59,7 +63,7 @@ fun SortBottomSheet(
 
             // Name Ascending
             ListItem(
-                headlineContent = { Text(stringResource(R.string.sort_name_asc)) },
+                content = { Text(stringResource(R.string.sort_name_asc)) },
                 leadingContent = {
                     Icon(Icons.Default.SortByAlpha, contentDescription = null)
                 },
@@ -71,7 +75,7 @@ fun SortBottomSheet(
 
             // Name Descending
             ListItem(
-                headlineContent = { Text(stringResource(R.string.sort_name_desc)) },
+                content = { Text(stringResource(R.string.sort_name_desc)) },
                 leadingContent = {
                     Icon(Icons.Default.SortByAlpha, contentDescription = null)
                 },
@@ -85,7 +89,7 @@ fun SortBottomSheet(
 
             // Date Added Ascending
             ListItem(
-                headlineContent = { Text(stringResource(R.string.sort_date_added_asc)) },
+                content = { Text(stringResource(R.string.sort_date_added_asc)) },
                 leadingContent = {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                 },
@@ -97,7 +101,7 @@ fun SortBottomSheet(
 
             // Date Added Descending
             ListItem(
-                headlineContent = { Text(stringResource(R.string.sort_date_added_desc)) },
+                content = { Text(stringResource(R.string.sort_date_added_desc)) },
                 leadingContent = {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                 },
@@ -111,7 +115,7 @@ fun SortBottomSheet(
 
             // Date Modified Ascending
             ListItem(
-                headlineContent = { Text(stringResource(R.string.sort_date_modified_asc)) },
+                content = { Text(stringResource(R.string.sort_date_modified_asc)) },
                 leadingContent = {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                 },
@@ -123,7 +127,7 @@ fun SortBottomSheet(
 
             // Date Modified Descending
             ListItem(
-                headlineContent = { Text(stringResource(R.string.sort_date_modified_desc)) },
+                content = { Text(stringResource(R.string.sort_date_modified_desc)) },
                 leadingContent = {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                 },

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/folder_view/FolderViewScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/folder_view/FolderViewScreen.kt
@@ -34,7 +34,7 @@ import com.anthonyla.paperize.presentation.theme.AppSpacing
 @Composable
 fun FolderViewScreen(
     onBackClick: () -> Unit,
-    onNavigateToWallpaperView: (String, String) -> Unit,
+    onNavigateToWallpaperView: (String, String, String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FolderViewViewModel = hiltViewModel()
 ) {
@@ -84,7 +84,13 @@ fun FolderViewScreen(
                     wallpaperUri = wallpaper.uri,
                     isSelected = false,
                     isSelectionMode = false,
-                    onClick = { onNavigateToWallpaperView(wallpaper.uri, wallpaper.fileName) },
+                    onClick = {
+                        onNavigateToWallpaperView(
+                            wallpaper.id,
+                            wallpaper.uri,
+                            wallpaper.fileName
+                        )
+                    },
                     onLongClick = { /* No selection in folder view */ },
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/home/HomeViewModel.kt
@@ -512,10 +512,15 @@ class HomeViewModel @Inject constructor(
         if (wallpaperMode.value == com.anthonyla.paperize.core.WallpaperMode.LIVE) {
             // LIVE mode: schedule live wallpaper changes
             if (settings.liveAlbumId != null && settings.liveIntervalMinutes > 0) {
-                wallpaperScheduler.scheduleWallpaperChange(
-                    ScreenType.LIVE,
-                    settings.liveIntervalMinutes
-                )
+                if (settings.liveIntervalMinutes >= Constants.MIN_INTERVAL_MINUTES) {
+                    wallpaperScheduler.scheduleWallpaperChange(
+                        ScreenType.LIVE,
+                        settings.liveIntervalMinutes
+                    )
+                } else {
+                    // The visible live-wallpaper engine owns sub-15-minute intervals.
+                    wallpaperScheduler.cancelWallpaperChange(ScreenType.LIVE)
+                }
                 wallpaperScheduler.scheduleAlbumRefresh()
             } else {
                 wallpaperScheduler.cancelWallpaperChange(ScreenType.LIVE)

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/sort/SortViewScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/sort/SortViewScreen.kt
@@ -332,7 +332,7 @@ fun SortViewScreen(
                                                     .clip(AppShapes.imageShape)
                                             )
                                         },
-                                        headlineContent = {
+                                        content = {
                                             Text(
                                                 text = currentFolder.name,
                                                 maxLines = 2,

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/WallpaperScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/WallpaperScreen.kt
@@ -542,11 +542,18 @@ fun WallpaperScreen(
                 TimeIntervalPicker(
                     title = stringResource(R.string.interval_text),
                     minutes = scheduleSettings.liveIntervalMinutes,
+                    minimumMinutes = Constants.MIN_LIVE_INTERVAL_MINUTES,
                     onMinutesChange = { minutes ->
                         onUpdateScheduleSettings(
                             scheduleSettings.copy(liveIntervalMinutes = minutes)
                         )
                     }
+                )
+                Text(
+                    text = stringResource(R.string.live_short_interval_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = AppSpacing.large)
                 )
             }
         }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/components/AlbumSelectionBottomSheet.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/components/AlbumSelectionBottomSheet.kt
@@ -28,8 +28,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -63,7 +64,7 @@ fun AlbumSelectionBottomSheet(
     onAlbumSelect: (AlbumSummary) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/components/TimeIntervalPicker.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper/components/TimeIntervalPicker.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -39,7 +40,8 @@ fun TimeIntervalPicker(
     title: String,
     minutes: Int,
     onMinutesChange: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    minimumMinutes: Int = Constants.MIN_INTERVAL_MINUTES
 ) {
     // Decompose incoming minutes value into days, hours, minutes
     val initialDays = minutes / Constants.MINUTES_PER_DAY
@@ -57,7 +59,7 @@ fun TimeIntervalPicker(
     var minuteInput by remember(minutes) { mutableStateOf(initialMins.toString()) }
 
     // Debounce state - tracks when user last made a change; reset when external `minutes` prop changes
-    var lastChangeTimestamp by remember(minutes) { mutableStateOf(0L) }
+    var lastChangeTimestamp by remember(minutes) { mutableLongStateOf(0L) }
 
     // Debounced update - only fires after user stops typing
     LaunchedEffect(dayValue, hourValue, minuteValue, lastChangeTimestamp) {
@@ -65,7 +67,7 @@ fun TimeIntervalPicker(
             delay(Constants.DEBOUNCE_DELAY_MS)
             val total = (dayValue * Constants.MINUTES_PER_DAY) + (hourValue * Constants.MINUTES_PER_HOUR) + minuteValue
             // Clamp between minimum and maximum interval
-            val clamped = min(max(total, Constants.MIN_INTERVAL_MINUTES), Constants.MAX_INTERVAL_MINUTES)
+            val clamped = min(max(total, minimumMinutes), Constants.MAX_INTERVAL_MINUTES)
             onMinutesChange(clamped)
         }
     }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper_view/WallpaperViewScreen.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper_view/WallpaperViewScreen.kt
@@ -3,11 +3,14 @@ package com.anthonyla.paperize.presentation.screens.wallpaper_view
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,19 +18,29 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.anthonyla.paperize.R
+import com.anthonyla.paperize.core.ScreenType
+import com.anthonyla.paperize.core.WallpaperMode
 import com.anthonyla.paperize.presentation.theme.AppSpacing
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
@@ -38,9 +51,12 @@ fun WallpaperViewScreen(
     wallpaperUri: String,
     wallpaperName: String,
     onBackClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: WallpaperViewViewModel = hiltViewModel()
 ) {
     val zoomState = rememberZoomState()
+    val wallpaperMode by viewModel.wallpaperMode.collectAsStateWithLifecycle()
+    var showApplyDialog by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -79,7 +95,27 @@ fun WallpaperViewScreen(
         bottomBar = {
             BottomAppBar(
                 containerColor = Color.Transparent,
-                actions = {}
+                actions = {
+                    if (wallpaperMode == WallpaperMode.STATIC) {
+                        Button(
+                            onClick = { showApplyDialog = true },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = AppSpacing.large)
+                        ) {
+                            Text(stringResource(R.string.set_wallpaper))
+                        }
+                    } else {
+                        Text(
+                            text = stringResource(R.string.individual_wallpaper_static_only),
+                            color = MaterialTheme.colorScheme.surfaceBright,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = AppSpacing.large)
+                        )
+                    }
+                }
             )
         }
     ) { padding ->
@@ -102,5 +138,36 @@ fun WallpaperViewScreen(
                 )
             }
         }
+    }
+
+    if (showApplyDialog) {
+        AlertDialog(
+            onDismissRequest = { showApplyDialog = false },
+            title = { Text(stringResource(R.string.set_wallpaper)) },
+            text = {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    listOf(
+                        ScreenType.HOME to R.string.home_screen_btn,
+                        ScreenType.LOCK to R.string.lock_screen_btn,
+                        ScreenType.BOTH to R.string.home_and_lock_screens
+                    ).forEach { (screenType, label) ->
+                        TextButton(
+                            onClick = {
+                                showApplyDialog = false
+                                viewModel.applyTo(screenType)
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(stringResource(label))
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showApplyDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper_view/WallpaperViewViewModel.kt
+++ b/app/src/main/java/com/anthonyla/paperize/presentation/screens/wallpaper_view/WallpaperViewViewModel.kt
@@ -1,0 +1,45 @@
+package com.anthonyla.paperize.presentation.screens.wallpaper_view
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.anthonyla.paperize.core.ScreenType
+import com.anthonyla.paperize.core.WallpaperMode
+import com.anthonyla.paperize.core.constants.Constants
+import com.anthonyla.paperize.domain.repository.SettingsRepository
+import com.anthonyla.paperize.presentation.common.navigation.WallpaperViewRoute
+import com.anthonyla.paperize.service.wallpaper.WallpaperChangeService
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class WallpaperViewViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context,
+    settingsRepository: SettingsRepository
+) : ViewModel() {
+    private val route = savedStateHandle.toRoute<WallpaperViewRoute>()
+
+    val wallpaperMode = settingsRepository.getWallpaperModeFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(Constants.FLOW_SUBSCRIPTION_TIMEOUT_MS),
+        initialValue = WallpaperMode.STATIC
+    )
+
+    fun applyTo(screenType: ScreenType) {
+        require(screenType != ScreenType.LIVE)
+        context.startForegroundService(
+            Intent(context, WallpaperChangeService::class.java).apply {
+                action = WallpaperChangeService.ACTION_APPLY_SPECIFIC_WALLPAPER
+                putExtra(WallpaperChangeService.EXTRA_WALLPAPER_ID, route.wallpaperId)
+                putExtra(WallpaperChangeService.EXTRA_SCREEN_TYPE, screenType.name)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/anthonyla/paperize/service/alarm/BootReceiver.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/alarm/BootReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.anthonyla.paperize.core.ScreenType
+import com.anthonyla.paperize.core.constants.Constants
 import com.anthonyla.paperize.domain.repository.SettingsRepository
 import com.anthonyla.paperize.service.worker.WallpaperScheduler
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,10 +55,14 @@ class BootReceiver : BroadcastReceiver() {
                         if (wallpaperMode == com.anthonyla.paperize.core.WallpaperMode.LIVE) {
                             // LIVE mode: schedule live wallpaper changes
                             if (settings.liveAlbumId != null && settings.liveIntervalMinutes > 0) {
-                                wallpaperScheduler.scheduleWallpaperChange(
-                                    ScreenType.LIVE,
-                                    settings.liveIntervalMinutes
-                                )
+                                if (settings.liveIntervalMinutes >= Constants.MIN_INTERVAL_MINUTES) {
+                                    wallpaperScheduler.scheduleWallpaperChange(
+                                        ScreenType.LIVE,
+                                        settings.liveIntervalMinutes
+                                    )
+                                } else {
+                                    wallpaperScheduler.cancelWallpaperChange(ScreenType.LIVE)
+                                }
                                 wallpaperScheduler.scheduleAlbumRefresh()
                                 Log.d(TAG, "Live wallpaper changes scheduled on boot")
                             } else {

--- a/app/src/main/java/com/anthonyla/paperize/service/livewallpaper/PaperizeLiveWallpaperService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/livewallpaper/PaperizeLiveWallpaperService.kt
@@ -12,6 +12,9 @@ import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import com.anthonyla.paperize.core.ScreenType
 import com.anthonyla.paperize.core.ScalingType
+import com.anthonyla.paperize.core.WallpaperMode
+import com.anthonyla.paperize.domain.model.ScheduleSettings
+import com.anthonyla.paperize.domain.model.usesVisibleLiveTimer
 import com.anthonyla.paperize.domain.repository.SettingsRepository
 import com.anthonyla.paperize.domain.repository.WallpaperRepository
 import com.anthonyla.paperize.service.livewallpaper.gl.GLWallpaperService
@@ -27,11 +30,14 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -106,6 +112,10 @@ class PaperizeLiveWallpaperService : GLWallpaperService(), LifecycleOwner {
         @Volatile private var currentWallpaper: Wallpaper? = null
         private var observedScalingType: ScalingType? = null
         private var hasShownParallaxWarning = false
+        private var engineVisible = false
+        private var latestSettings = ScheduleSettings.default()
+        private var latestWallpaperMode = WallpaperMode.STATIC
+        private var liveIntervalJob: Job? = null
 
         private val gestureDetector = GestureDetector(
             this@PaperizeLiveWallpaperService,
@@ -122,6 +132,7 @@ class PaperizeLiveWallpaperService : GLWallpaperService(), LifecycleOwner {
                 if (intent?.action == Constants.ACTION_RELOAD_WALLPAPER) {
                     Log.d(TAG, "Received reload broadcast")
                     renderController.reloadCurrentArtwork(com.anthonyla.paperize.service.livewallpaper.renderer.ReloadImmediate)
+                    restartLiveIntervalTimer()
                 }
             }
         }
@@ -280,6 +291,15 @@ class PaperizeLiveWallpaperService : GLWallpaperService(), LifecycleOwner {
                 }.catch { e ->
                     Log.e(TAG, "Error observing settings", e)
                 }.collect { (settings, mode) ->
+                    val timerConfigurationChanged =
+                        latestWallpaperMode != mode ||
+                            latestSettings.enableChanger != settings.enableChanger ||
+                            latestSettings.liveAlbumId != settings.liveAlbumId ||
+                            latestSettings.liveIntervalMinutes != settings.liveIntervalMinutes
+                    latestSettings = settings
+                    latestWallpaperMode = mode
+                    if (timerConfigurationChanged) restartLiveIntervalTimer()
+
                     // Only process settings in LIVE mode
                     // In STATIC mode, the static wallpaper worker handles HOME/LOCK screens
                     if (mode != com.anthonyla.paperize.core.WallpaperMode.LIVE) {
@@ -344,12 +364,14 @@ class PaperizeLiveWallpaperService : GLWallpaperService(), LifecycleOwner {
         }
 
         override fun onVisibilityChanged(visible: Boolean) {
+            engineVisible = visible
             renderController.visible = visible
             if (visible) {
                 // Re-evaluate draw-time effects such as adaptive brightness after
                 // configuration changes while the wallpaper was hidden.
                 requestRender()
             }
+            restartLiveIntervalTimer()
             super.onVisibilityChanged(visible)
         }
 
@@ -412,6 +434,7 @@ class PaperizeLiveWallpaperService : GLWallpaperService(), LifecycleOwner {
 
                 if (doubleTapEnabled) {
                     renderController.reloadCurrentArtwork(com.anthonyla.paperize.service.livewallpaper.renderer.ReloadImmediate)
+                    restartLiveIntervalTimer()
                 }
             }
         }
@@ -423,6 +446,32 @@ class PaperizeLiveWallpaperService : GLWallpaperService(), LifecycleOwner {
                     Log.d(TAG, "Screen off - changing wallpaper")
                     // Use forceReload to bypass visibility check and load while screen is off
                     renderController.forceReloadCurrentArtwork()
+                }
+            }
+        }
+
+        private fun restartLiveIntervalTimer() {
+            liveIntervalJob?.cancel()
+            liveIntervalJob = null
+
+            val intervalMinutes = latestSettings.liveIntervalMinutes
+            val shouldRun =
+                engineVisible &&
+                    !isPreview &&
+                    latestWallpaperMode == WallpaperMode.LIVE &&
+                    latestSettings.enableChanger &&
+                    latestSettings.liveAlbumId != null &&
+                    usesVisibleLiveTimer(intervalMinutes)
+            if (!shouldRun) return
+
+            liveIntervalJob = engineScope.launch {
+                val intervalMillis = intervalMinutes.toLong() * 60_000L
+                while (isActive) {
+                    delay(intervalMillis)
+                    Log.d(TAG, "Visible live interval elapsed; changing wallpaper")
+                    renderController.reloadCurrentArtwork(
+                        com.anthonyla.paperize.service.livewallpaper.renderer.ReloadImmediate
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/anthonyla/paperize/service/tile/WallpaperTileService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/tile/WallpaperTileService.kt
@@ -2,64 +2,20 @@ package com.anthonyla.paperize.service.tile
 
 import android.content.Intent
 import android.service.quicksettings.TileService
-import android.util.Log
-import com.anthonyla.paperize.core.ScreenType
-import com.anthonyla.paperize.core.WallpaperMode
-import com.anthonyla.paperize.core.constants.Constants
-import com.anthonyla.paperize.domain.repository.SettingsRepository
 import com.anthonyla.paperize.service.wallpaper.WallpaperChangeService
-import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /**
  * Quick Settings Tile for changing wallpaper
  */
-@AndroidEntryPoint
 class WallpaperTileService : TileService() {
-
-    @Inject
-    lateinit var settingsRepository: SettingsRepository
-
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    companion object {
-        private const val TAG = "WallpaperTileService"
-    }
 
     override fun onClick() {
         super.onClick()
 
-        serviceScope.launch {
-            try {
-                val mode = settingsRepository.getWallpaperMode()
-
-                if (mode == WallpaperMode.LIVE) {
-                    // Send broadcast to trigger live wallpaper reload
-                    val intent = Intent(Constants.ACTION_RELOAD_WALLPAPER)
-                    intent.setPackage(packageName)
-                    sendBroadcast(intent)
-                } else {
-                    // Start wallpaper change service for static wallpaper
-                    // Use BOTH to ensure synchronized change if configured, or both if not
-                    val intent = Intent(this@WallpaperTileService, WallpaperChangeService::class.java).apply {
-                        action = Constants.ACTION_CHANGE_WALLPAPER
-                        putExtra(Constants.EXTRA_SCREEN_TYPE, ScreenType.BOTH.name)
-                    }
-                    startForegroundService(intent)
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error handling tile click", e)
+        startForegroundService(
+            Intent(this, WallpaperChangeService::class.java).apply {
+                action = WallpaperChangeService.ACTION_CHANGE_WALLPAPER_AUTO
             }
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        serviceScope.cancel()
+        )
     }
 }

--- a/app/src/main/java/com/anthonyla/paperize/service/wallpaper/WallpaperChangeService.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/wallpaper/WallpaperChangeService.kt
@@ -7,6 +7,7 @@ import android.app.Service
 import android.app.WallpaperManager
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.graphics.Bitmap
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -21,10 +22,12 @@ import com.anthonyla.paperize.core.util.setBitmapChecked
 import com.anthonyla.paperize.domain.model.PreparedWallpaper
 import com.anthonyla.paperize.domain.model.ScheduleSettings
 import com.anthonyla.paperize.domain.repository.SettingsRepository
+import com.anthonyla.paperize.domain.repository.WallpaperRepository
 import com.anthonyla.paperize.domain.usecase.ChangeWallpaperUseCase
 import com.anthonyla.paperize.domain.usecase.ReapplyEffectsUseCase
 import com.anthonyla.paperize.presentation.MainActivity
 import com.anthonyla.paperize.service.WallpaperChangeLock
+import com.anthonyla.paperize.service.worker.WallpaperScheduler
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +47,8 @@ class WallpaperChangeService : Service() {
     @Inject lateinit var reapplyEffectsUseCase: ReapplyEffectsUseCase
     @Inject lateinit var settingsRepository: SettingsRepository
     @Inject lateinit var wallpaperChangeLock: WallpaperChangeLock
+    @Inject lateinit var wallpaperScheduler: WallpaperScheduler
+    @Inject lateinit var wallpaperRepository: WallpaperRepository
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var wallpaperManager: WallpaperManager
@@ -74,6 +79,11 @@ class WallpaperChangeService : Service() {
             ACTION_CHANGE_WALLPAPER -> handleChangeWallpaper(screenType, startId)
             ACTION_CHANGE_WALLPAPER_AUTO ->
                 handleChangeWallpaper(screenType, startId, respectWallpaperMode = true)
+            ACTION_APPLY_SPECIFIC_WALLPAPER -> handleApplySpecificWallpaper(
+                wallpaperId = intent.getStringExtra(EXTRA_WALLPAPER_ID),
+                screenType = screenType,
+                startId = startId
+            )
             ACTION_REAPPLY_EFFECTS -> handleReapplyEffects(screenType, startId)
             else -> {
                 Log.w(TAG, "Unknown action: ${intent?.action}")
@@ -91,19 +101,24 @@ class WallpaperChangeService : Service() {
         serviceScope.launch {
             wallpaperChangeLock.mutex.withLock {
                 try {
+                    val wallpaperMode = settingsRepository.getWallpaperMode()
                     val effectiveScreenType =
                         if (
                             respectWallpaperMode &&
-                            settingsRepository.getWallpaperMode() == WallpaperMode.LIVE
+                            wallpaperMode == WallpaperMode.LIVE
                         ) {
                             ScreenType.LIVE
                         } else {
                             screenType
                         }
-                    changeWallpaper(
-                        effectiveScreenType,
-                        settingsRepository.getScheduleSettings()
-                    )
+                    val settings = settingsRepository.getScheduleSettings()
+                    if (changeWallpaper(effectiveScreenType, settings)) {
+                        wallpaperScheduler.resetAfterManualChange(
+                            effectiveScreenType,
+                            settings,
+                            wallpaperMode
+                        )
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Error changing wallpaper", e)
                     showErrorNotification(
@@ -121,22 +136,23 @@ class WallpaperChangeService : Service() {
     private suspend fun changeWallpaper(
         screenType: ScreenType,
         settings: ScheduleSettings
-    ) {
+    ): Boolean =
         when (screenType) {
             ScreenType.LIVE -> {
                 sendBroadcast(
                     Intent(Constants.ACTION_RELOAD_WALLPAPER).setPackage(packageName)
                 )
                 Log.d(TAG, "Requested immediate live wallpaper reload")
+                true
             }
 
             ScreenType.HOME -> settings.homeAlbumId?.let {
                 changeSingle(it, ScreenType.HOME)
-            } ?: Log.w(TAG, "No home album selected")
+            } ?: false.also { Log.w(TAG, "No home album selected") }
 
             ScreenType.LOCK -> settings.lockAlbumId?.let {
                 changeSingle(it, ScreenType.LOCK)
-            } ?: Log.w(TAG, "No lock album selected")
+            } ?: false.also { Log.w(TAG, "No lock album selected") }
 
             ScreenType.BOTH -> {
                 val homeAlbumId = settings.homeAlbumId
@@ -148,19 +164,20 @@ class WallpaperChangeService : Service() {
                 ) {
                     changeSynchronized(homeAlbumId, settings)
                 } else {
-                    homeAlbumId?.let { changeSingle(it, ScreenType.HOME) }
+                    var changed = false
+                    homeAlbumId?.let { changed = changeSingle(it, ScreenType.HOME) || changed }
                         ?: Log.w(TAG, "No home album selected")
-                    lockAlbumId?.let { changeSingle(it, ScreenType.LOCK) }
+                    lockAlbumId?.let { changed = changeSingle(it, ScreenType.LOCK) || changed }
                         ?: Log.w(TAG, "No lock album selected")
+                    changed
                 }
             }
         }
-    }
 
     private suspend fun changeSynchronized(
         albumId: String,
         settings: ScheduleSettings
-    ) {
+    ): Boolean =
         when (val result = changeWallpaperUseCase(albumId, ScreenType.HOME)) {
             is PaperizeResult.Success -> {
                 val prepared = result.data
@@ -209,11 +226,13 @@ class WallpaperChangeService : Service() {
                         PaperizeResult.Loading -> error("Unexpected loading result")
                     }
                 }
+                true
             }
 
             is PaperizeResult.Error -> {
                 if (result.exception is EmptyAlbumException) {
                     handleEmptyAlbumError(ScreenType.BOTH)
+                    false
                 } else {
                     throw asException(result.exception)
                 }
@@ -221,12 +240,11 @@ class WallpaperChangeService : Service() {
 
             PaperizeResult.Loading -> error("Unexpected loading result")
         }
-    }
 
     private suspend fun changeSingle(
         albumId: String,
         screenType: ScreenType
-    ) {
+    ): Boolean =
         when (val result = changeWallpaperUseCase(albumId, screenType)) {
             is PaperizeResult.Success -> {
                 val which = when (screenType) {
@@ -236,11 +254,13 @@ class WallpaperChangeService : Service() {
                 }
                 applyPrepared(result.data, which, listOf(screenType))
                 Log.d(TAG, "$screenType wallpaper changed successfully")
+                true
             }
 
             is PaperizeResult.Error -> {
                 if (result.exception is EmptyAlbumException) {
                     handleEmptyAlbumError(screenType)
+                    false
                 } else {
                     throw asException(result.exception)
                 }
@@ -248,7 +268,6 @@ class WallpaperChangeService : Service() {
 
             PaperizeResult.Loading -> error("Unexpected loading result")
         }
-    }
 
     private suspend fun applyPrepared(
         prepared: PreparedWallpaper,
@@ -270,6 +289,140 @@ class WallpaperChangeService : Service() {
         } finally {
             prepared.bitmap.recycle()
         }
+    }
+
+    private fun handleApplySpecificWallpaper(
+        wallpaperId: String?,
+        screenType: ScreenType,
+        startId: Int
+    ) {
+        serviceScope.launch {
+            wallpaperChangeLock.mutex.withLock {
+                try {
+                    require(!wallpaperId.isNullOrBlank()) { getString(R.string.wallpaper_not_found) }
+                    require(screenType != ScreenType.LIVE) { getString(R.string.static_mode_required) }
+                    val wallpaperMode = settingsRepository.getWallpaperMode()
+                    require(wallpaperMode == WallpaperMode.STATIC) {
+                        getString(R.string.static_mode_required)
+                    }
+                    val wallpaper = wallpaperRepository.getWallpaperById(wallpaperId)
+                        ?: error(getString(R.string.wallpaper_not_found))
+                    val settings = settingsRepository.getScheduleSettings()
+
+                    applySpecificWallpaper(
+                        albumId = wallpaper.albumId,
+                        wallpaperId = wallpaper.id,
+                        screenType = screenType,
+                        settings = settings
+                    )
+                    wallpaperScheduler.resetAfterManualChange(
+                        screenType = screenType,
+                        settings = settings,
+                        wallpaperMode = wallpaperMode
+                    )
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error applying selected wallpaper", e)
+                    showErrorNotification(
+                        getString(R.string.app_name),
+                        e.localizedMessage ?: getString(R.string.error_no_valid_wallpaper_after_retries)
+                    )
+                } finally {
+                    stopSelf(startId)
+                }
+            }
+        }
+    }
+
+    private suspend fun applySpecificWallpaper(
+        albumId: String,
+        wallpaperId: String,
+        screenType: ScreenType,
+        settings: ScheduleSettings
+    ) {
+        when (screenType) {
+            ScreenType.HOME, ScreenType.LOCK -> applySpecificSingle(
+                albumId,
+                wallpaperId,
+                screenType,
+                settings.shuffleEnabled
+            )
+
+            ScreenType.BOTH -> {
+                val samePresentation =
+                    settings.homeEffects == settings.lockEffects &&
+                        settings.homeScalingType == settings.lockScalingType &&
+                        !settings.homeScrollingEnabled
+                if (samePresentation) {
+                    val bitmap = renderSpecific(albumId, wallpaperId, ScreenType.HOME)
+                    try {
+                        wallpaperManager.setBitmapChecked(
+                            bitmap,
+                            WallpaperManager.FLAG_SYSTEM or WallpaperManager.FLAG_LOCK
+                        )
+                        changeWallpaperUseCase.completeSpecific(
+                            albumId,
+                            ScreenType.HOME,
+                            wallpaperId,
+                            settings.shuffleEnabled
+                        )
+                        changeWallpaperUseCase.completeSpecific(
+                            albumId,
+                            ScreenType.LOCK,
+                            wallpaperId,
+                            settings.shuffleEnabled
+                        )
+                    } finally {
+                        bitmap.recycle()
+                    }
+                } else {
+                    applySpecificSingle(
+                        albumId,
+                        wallpaperId,
+                        ScreenType.HOME,
+                        settings.shuffleEnabled
+                    )
+                    applySpecificSingle(
+                        albumId,
+                        wallpaperId,
+                        ScreenType.LOCK,
+                        settings.shuffleEnabled
+                    )
+                }
+            }
+
+            ScreenType.LIVE -> error(getString(R.string.static_mode_required))
+        }
+        Log.d(TAG, "Selected wallpaper applied to $screenType")
+    }
+
+    private suspend fun applySpecificSingle(
+        albumId: String,
+        wallpaperId: String,
+        screenType: ScreenType,
+        shuffle: Boolean
+    ) {
+        val bitmap = renderSpecific(albumId, wallpaperId, screenType)
+        try {
+            val which = if (screenType == ScreenType.HOME) {
+                WallpaperManager.FLAG_SYSTEM
+            } else {
+                WallpaperManager.FLAG_LOCK
+            }
+            wallpaperManager.setBitmapChecked(bitmap, which)
+            changeWallpaperUseCase.completeSpecific(albumId, screenType, wallpaperId, shuffle)
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private suspend fun renderSpecific(
+        albumId: String,
+        wallpaperId: String,
+        screenType: ScreenType
+    ): Bitmap = when (val result = reapplyEffectsUseCase(albumId, screenType, wallpaperId)) {
+        is PaperizeResult.Success -> result.data
+        is PaperizeResult.Error -> throw asException(result.exception)
+        PaperizeResult.Loading -> error("Unexpected loading result")
     }
 
     private fun handleReapplyEffects(screenType: ScreenType, startId: Int) {
@@ -384,7 +537,7 @@ class WallpaperChangeService : Service() {
         return NotificationCompat.Builder(this, Constants.NOTIFICATION_CHANNEL_ID)
             .setContentTitle(getString(R.string.app_name))
             .setContentText(getString(R.string.changing_wallpaper))
-            .setSmallIcon(R.drawable.ic_launcher_monochrome)
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentIntent(pendingIntent)
             .setOngoing(true)
             .build()
@@ -400,7 +553,7 @@ class WallpaperChangeService : Service() {
         val notification = NotificationCompat.Builder(this, Constants.NOTIFICATION_CHANNEL_ID)
             .setContentTitle(title)
             .setContentText(message)
-            .setSmallIcon(R.drawable.ic_launcher_monochrome)
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
@@ -423,8 +576,10 @@ class WallpaperChangeService : Service() {
         const val ACTION_CHANGE_WALLPAPER = Constants.ACTION_CHANGE_WALLPAPER
         const val ACTION_CHANGE_WALLPAPER_AUTO =
             "com.anthonyla.paperize.ACTION_CHANGE_WALLPAPER_AUTO"
+        const val ACTION_APPLY_SPECIFIC_WALLPAPER = Constants.ACTION_APPLY_SPECIFIC_WALLPAPER
         const val ACTION_REAPPLY_EFFECTS = Constants.ACTION_REAPPLY_EFFECTS
         const val EXTRA_SCREEN_TYPE = Constants.EXTRA_SCREEN_TYPE
+        const val EXTRA_WALLPAPER_ID = Constants.EXTRA_WALLPAPER_ID
         private const val ERROR_NOTIFICATION_ID = Constants.NOTIFICATION_ID + 1
     }
 }

--- a/app/src/main/java/com/anthonyla/paperize/service/worker/WallpaperScheduler.kt
+++ b/app/src/main/java/com/anthonyla/paperize/service/worker/WallpaperScheduler.kt
@@ -10,7 +10,9 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import kotlinx.coroutines.flow.first
 import com.anthonyla.paperize.core.ScreenType
+import com.anthonyla.paperize.core.WallpaperMode
 import com.anthonyla.paperize.core.constants.Constants
+import com.anthonyla.paperize.domain.model.ScheduleSettings
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -52,7 +54,8 @@ class WallpaperScheduler @Inject constructor(
         screenType: ScreenType,
         intervalMinutes: Int,
         networkRequired: Boolean = false,
-        requireCharging: Boolean = false
+        requireCharging: Boolean = false,
+        resetInterval: Boolean = false
     ) {
 
         val adjustedInterval = intervalMinutes.toLong().coerceAtLeast(Constants.MIN_INTERVAL_MINUTES.toLong())
@@ -81,15 +84,39 @@ class WallpaperScheduler @Inject constructor(
             .addTag(getWorkTag(screenType))
             .build()
 
-        // Enqueue work with UPDATE policy to update existing work without triggering immediate run
-        // Only runs immediately on first setup when no existing work exists
+        // UPDATE preserves the existing period for settings edits. A successful manual change uses
+        // CANCEL_AND_REENQUEUE so the next automatic change waits for one complete interval.
         workManager.enqueueUniquePeriodicWork(
             workName,
-            ExistingPeriodicWorkPolicy.UPDATE,
+            if (resetInterval) {
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
+            } else {
+                ExistingPeriodicWorkPolicy.UPDATE
+            },
             workRequest
         )
 
         Log.d(TAG, "Scheduled $screenType wallpaper change every $adjustedInterval minutes")
+    }
+
+    /** Reset only the automatic schedules affected by a successful manual change. */
+    fun resetAfterManualChange(
+        screenType: ScreenType,
+        settings: ScheduleSettings,
+        wallpaperMode: WallpaperMode
+    ) {
+        scheduledScreensToReset(screenType, settings, wallpaperMode).forEach { scheduledScreen ->
+            val interval = when (scheduledScreen) {
+                ScreenType.HOME, ScreenType.BOTH -> settings.homeIntervalMinutes
+                ScreenType.LOCK -> settings.lockIntervalMinutes
+                ScreenType.LIVE -> settings.liveIntervalMinutes
+            }
+            scheduleWallpaperChange(
+                screenType = scheduledScreen,
+                intervalMinutes = interval,
+                resetInterval = true
+            )
+        }
     }
 
     /**
@@ -323,6 +350,46 @@ class WallpaperScheduler @Inject constructor(
         return workInfos.any { workInfo ->
             workInfo.state == androidx.work.WorkInfo.State.ENQUEUED ||
             workInfo.state == androidx.work.WorkInfo.State.RUNNING
+        }
+    }
+}
+
+/** Pure scheduling policy shared with tests. */
+internal fun scheduledScreensToReset(
+    manualScreen: ScreenType,
+    settings: ScheduleSettings,
+    wallpaperMode: WallpaperMode
+): Set<ScreenType> {
+    if (!settings.enableChanger) return emptySet()
+
+    if (wallpaperMode == WallpaperMode.LIVE) {
+        return if (
+            manualScreen == ScreenType.LIVE &&
+            settings.liveAlbumId != null &&
+            settings.liveIntervalMinutes >= Constants.MIN_INTERVAL_MINUTES
+        ) {
+            setOf(ScreenType.LIVE)
+        } else {
+            emptySet()
+        }
+    }
+
+    if (manualScreen == ScreenType.LIVE) return emptySet()
+
+    val homeActive = settings.homeEnabled && settings.homeAlbumId != null
+    val lockActive = settings.lockEnabled && settings.lockAlbumId != null
+    val synchronized = homeActive && lockActive &&
+        settings.homeAlbumId == settings.lockAlbumId &&
+        !settings.separateSchedules
+
+    if (synchronized) return setOf(ScreenType.BOTH)
+
+    return buildSet {
+        if ((manualScreen == ScreenType.HOME || manualScreen == ScreenType.BOTH) && homeActive) {
+            add(ScreenType.HOME)
+        }
+        if ((manualScreen == ScreenType.LOCK || manualScreen == ScreenType.BOTH) && lockActive) {
+            add(ScreenType.LOCK)
         }
     }
 }

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M7,2h11c1.1,0 2,0.9 2,2v14h-2V4H7V2z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M4,5h11c1.1,0 2,0.9 2,2v13c0,1.1 -0.9,2 -2,2H4c-1.1,0 -2,-0.9 -2,-2V7c0,-1.1 0.9,-2 2,-2zM5,8a1.5,1.5 0,1 0,0 3a1.5,1.5 0,0 0,0 -3zM4,19h11l-3.5,-5l-2.5,3l-1.5,-2L4,19z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
   <string name="mins">Mins</string>
   <string name="total_interval">Total: </string>
   <string name="time_unit_min">min</string>
+  <string name="live_short_interval_note">Intervals under 15 minutes run only while Paperize is the visible live wallpaper.</string>
 
     <!-- Notification Service -->
   <string name="notification_channel_description">Wallpaper change notifications</string>
@@ -158,6 +159,8 @@
   <!-- Error Messages -->
   <string name="error_failed_to_build_queue">Failed to build wallpaper queue</string>
   <string name="error_no_valid_wallpaper_after_retries">Could not find a valid wallpaper after retries</string>
+  <string name="wallpaper_not_found">This wallpaper is no longer available.</string>
+  <string name="static_mode_required">Switch to static wallpaper mode before applying an individual wallpaper.</string>
 
     <!-- OEM Compatibility Warnings -->
   <string name="parallax_may_not_work">Parallax effect may not work with your OEM or launcher.</string>
@@ -211,6 +214,9 @@
   <string name="optimizing">Optimizing (May delay changes)</string>
   <string name="reliability">Reliability</string>
   <string name="change_wallpaper_now">Change wallpaper now</string>
+  <string name="set_wallpaper">Set wallpaper</string>
+  <string name="home_and_lock_screens">Home and lock screens</string>
+  <string name="individual_wallpaper_static_only">Switch to static mode to set an individual wallpaper.</string>
   <string name="change_next_wallpaper_shortcut">Change to the next configured wallpaper</string>
 
 </resources>

--- a/app/src/test/java/com/anthonyla/paperize/domain/model/ScheduleSettingsTest.kt
+++ b/app/src/test/java/com/anthonyla/paperize/domain/model/ScheduleSettingsTest.kt
@@ -26,7 +26,7 @@ class ScheduleSettingsTest {
         
         assertEquals(Constants.MIN_INTERVAL_MINUTES, validated.homeIntervalMinutes)
         assertEquals(Constants.MIN_INTERVAL_MINUTES, validated.lockIntervalMinutes)
-        assertEquals(Constants.MIN_INTERVAL_MINUTES, validated.liveIntervalMinutes)
+        assertEquals(Constants.MIN_LIVE_INTERVAL_MINUTES, validated.liveIntervalMinutes)
     }
 
     @Test
@@ -42,6 +42,15 @@ class ScheduleSettingsTest {
         assertEquals(60, validated.homeIntervalMinutes)
         assertEquals(120, validated.lockIntervalMinutes)
         assertEquals(30, validated.liveIntervalMinutes)
+    }
+
+    @Test
+    fun `visible live timer is used only below WorkManager minimum`() {
+        assertFalse(usesVisibleLiveTimer(0))
+        assertTrue(usesVisibleLiveTimer(1))
+        assertTrue(usesVisibleLiveTimer(14))
+        assertFalse(usesVisibleLiveTimer(15))
+        assertFalse(usesVisibleLiveTimer(60))
     }
 
     @Test

--- a/app/src/test/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCaseTest.kt
+++ b/app/src/test/java/com/anthonyla/paperize/domain/usecase/ChangeWallpaperUseCaseTest.kt
@@ -69,6 +69,25 @@ class ChangeWallpaperUseCaseTest {
         }
     }
 
+    @Test
+    fun `complete specific records selected item and respects shuffle`() = runTest {
+        coEvery {
+            repository.getNextWallpaperInQueue("album", ScreenType.HOME)
+        } returns null
+        coEvery {
+            repository.buildWallpaperQueue("album", ScreenType.HOME, true)
+        } returns Result.Success(Unit)
+
+        useCase.completeSpecific("album", ScreenType.HOME, "selected", shuffle = true)
+
+        coVerifyOrder {
+            repository.setCurrentWallpaper("album", ScreenType.HOME, "selected")
+            repository.getNextWallpaperInQueue("album", ScreenType.HOME)
+            repository.buildWallpaperQueue("album", ScreenType.HOME, true)
+            repository.removeWallpaperFromQueue("album", ScreenType.HOME, "selected")
+        }
+    }
+
     private fun preparedWallpaper() = PreparedWallpaper(
         bitmap = mockk<Bitmap>(relaxed = true),
         albumId = "album",

--- a/app/src/test/java/com/anthonyla/paperize/service/worker/WallpaperSchedulingPolicyTest.kt
+++ b/app/src/test/java/com/anthonyla/paperize/service/worker/WallpaperSchedulingPolicyTest.kt
@@ -1,0 +1,76 @@
+package com.anthonyla.paperize.service.worker
+
+import com.anthonyla.paperize.core.ScreenType
+import com.anthonyla.paperize.core.WallpaperMode
+import com.anthonyla.paperize.domain.model.ScheduleSettings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WallpaperSchedulingPolicyTest {
+    @Test
+    fun `manual synchronized change resets the shared job`() {
+        val settings = ScheduleSettings(
+            enableChanger = true,
+            homeEnabled = true,
+            lockEnabled = true,
+            homeAlbumId = "album",
+            lockAlbumId = "album"
+        )
+
+        assertEquals(
+            setOf(ScreenType.BOTH),
+            scheduledScreensToReset(ScreenType.HOME, settings, WallpaperMode.STATIC)
+        )
+    }
+
+    @Test
+    fun `manual both change resets each independent job`() {
+        val settings = ScheduleSettings(
+            enableChanger = true,
+            separateSchedules = true,
+            homeEnabled = true,
+            lockEnabled = true,
+            homeAlbumId = "home",
+            lockAlbumId = "lock"
+        )
+
+        assertEquals(
+            setOf(ScreenType.HOME, ScreenType.LOCK),
+            scheduledScreensToReset(ScreenType.BOTH, settings, WallpaperMode.STATIC)
+        )
+    }
+
+    @Test
+    fun `manual change does not create a disabled schedule`() {
+        assertEquals(
+            emptySet<ScreenType>(),
+            scheduledScreensToReset(
+                ScreenType.BOTH,
+                ScheduleSettings(enableChanger = false),
+                WallpaperMode.STATIC
+            )
+        )
+    }
+
+    @Test
+    fun `short live interval belongs to visible engine instead of WorkManager`() {
+        val settings = ScheduleSettings(
+            enableChanger = true,
+            liveAlbumId = "live",
+            liveIntervalMinutes = 14
+        )
+
+        assertEquals(
+            emptySet<ScreenType>(),
+            scheduledScreensToReset(ScreenType.LIVE, settings, WallpaperMode.LIVE)
+        )
+        assertEquals(
+            setOf(ScreenType.LIVE),
+            scheduledScreensToReset(
+                ScreenType.LIVE,
+                settings.copy(liveIntervalMinutes = 15),
+                WallpaperMode.LIVE
+            )
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-androidGradlePlugin = "9.3.1"
-kotlin = "2.3.20"
+androidGradlePlugin = "9.3.2"
+kotlin = "2.4.10"
 hilt = "2.60.1"
 ksp = "2.3.11"
-material = "1.13.0"
-coil = "3.4.0"
+material = "1.14.0"
+coil = "3.6.0"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version = "0.37.3" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.13.0" }
 androidx-animation = { module = "androidx.compose.animation:animation" }
-androidx-compose-bom = { module = "androidx.compose:compose-bom", version = "2026.06.01" }
-androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.18.0" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version = "2026.08.00" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.19.0" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.2.0" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version = "1.2.1" }
 androidx-datastore = { module = "androidx.datastore:datastore", version = "1.2.1" }
@@ -19,19 +19,19 @@ androidx-documentfile = { module = "androidx.documentfile:documentfile", version
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.7.0" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version = "1.4.2" }
 androidx-foundation = { module = "androidx.compose.foundation:foundation" }
-androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.3.0" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.4.0" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version = "1.4.0" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version = "1.4.0" }
 androidx-junit = { module = "androidx.test.ext:junit", version = "1.3.0" }
-androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version = "2.10.0" }
-androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.10.0" }
-androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version = "2.10.0" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version = "2.11.0" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.11.0" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version = "2.11.0" }
 androidx-material = { module = "androidx.compose.material:material" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 # v4 uses Material 3 expressive APIs that are not available in the stable 1.4 line.
 # Keep this known-good alpha pinned until the expressive API reaches stable.
-androidx-material3 = { module = "androidx.compose.material3:material3", version = "1.5.0-alpha16" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version = "2.9.8" }
+androidx-material3 = { module = "androidx.compose.material3:material3", version = "1.5.0-alpha27" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version = "2.10.0" }
 androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version = "1.4.1" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version = "2.8.4" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version = "2.8.4" }
@@ -56,7 +56,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 lazycolumnscrollbar = { module = "com.github.nanihadesuka:LazyColumnScrollbar", version = "2.2.0" }
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version = "6.7.1" }
 toolbar-compose = { module = "me.onebone:toolbar-compose", version = "2.3.5" }
-zoomable = { module = "net.engawapg.lib:zoomable", version = "2.11.1" }
+zoomable = { module = "net.engawapg.lib:zoomable", version = "2.13.0" }
 reorderable = { group = "sh.calvin.reorderable", name = "reorderable", version = "3.1.0" }
 
 [plugins]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

- add exact home, lock, and combined wallpaper application from image previews
- reset affected schedules after successful manual changes and support one-minute visible live-wallpaper intervals
- replace the undersized notification icon
- update the Android 17 build toolchain, dependencies, and GitHub Actions
- prepare version 4.1.0 and its changelog

## Verification

- 277/277 unit tests
- Android 16 phone emulator: static home/lock/both application, dynamic colors, notification rendering, scheduling reset, live timer/lifecycle, double tap, screen-off, and every live effect
- Android 17 foldable emulator: 13/13 instrumentation tests, including static effects/scaling, live OpenGL shader pixels, wallpaper colors, and foldable sizing
- `lintDebug` (zero errors)
- minified `assembleRelease`