### PR TITLE
chore: prepare Paperize v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v4.1.1
+
+- Added Simplified Chinese translations for setup, settings, wallpaper controls,
+  notifications, and accessibility labels, with Android app-language support.
+- Corrected the privacy notice to explain that Paperize displays its own
+  notifications and does not read notifications from other apps.
+
+## New Contributors
+
+* @zxiaoshen made their first contribution in https://github.com/Anthonyy232/Paperize/pull/605
+
+**Full Changelog**: https://github.com/Anthonyy232/Paperize/compare/v4.1.0...v4.1.1
+
 ## v4.1.0
 
 - Added a Set wallpaper action to image previews, with separate home, lock, and

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.anthonyla.paperize"
         minSdk = 31
         targetSdk = 36
-        versionCode = 55
-        versionName = "4.1.0"
+        versionCode = 56
+        versionName = "4.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Prepare v4.1.1 (version code 56) after the reviewed Simplified Chinese contribution in #605.
- Record the notification/privacy wording correction and credit @zxiaoshen.
- Keep the existing vX.Y.Z title, bullet, contributor, and comparison-link style.

## Verification
- #605 passed updated-head unit CI and Actions/Java-Kotlin CodeQL.
- Resource validation passed for all 179 strings and three plural resources.
- Chinese onboarding, privacy text, and the main UI were checked on the Android 17 foldable emulator; all 13 static-image/OpenGL device tests passed.
- A fresh versioned unit/build/lint/device run is in progress. Master and tag signed APKs will be inspected and smoke-tested before publishing the draft release.

No sweep notes or maintenance checklist files are included. #604 remains open pending the reporter's clarification; this release does not claim to implement that feature.